### PR TITLE
don't clear callData on the first answer callback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-callkit",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Cordova plugin that lets you use iOS CallKit UI (with PushKit) and Android ConnectionService UI",
   "cordova": {
     "id": "cordova-plugin-callkit",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="cordova-plugin-callkit" version="1.1.2" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="cordova-plugin-callkit" version="1.1.3" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>Cordova CallKit</name>
 
     <js-module name="VoIPPushNotification" src="www/VoIPPushNotification.js">

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -610,13 +610,13 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
             CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:callData];
             [pluginResult setKeepCallbackAsBool:YES];
             [self.commandDelegate sendPluginResult:pluginResult callbackId:callbackId];
-            callData = nil; // clear out the data in case CordovaCall.receiveCall('caller'); called from JS side
 
             // CDVPluginResult* pluginResult = nil;
             // pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"answer event called successfully"];
             // [pluginResult setKeepCallbackAsBool:YES];
             // [self.commandDelegate sendPluginResult:pluginResult callbackId:callbackId];
         }
+        callData = nil; // clear out the data in case CordovaCall.receiveCall('caller'); called from JS side
     } else if ([response isEqualToString:@"reject"]) {
         for (id callbackId in callbackIds[@"reject"]) {
             CDVPluginResult* pluginResult = nil;


### PR DESCRIPTION
If there are multiple cordova listeners for `onAnswer` (not sure how it happens...), don't clear the `callData` on the first callback. This could explain why sometimes answering opens the app does nothing and stays on the dashboard.