### PR TITLE
comment out the offending code that's overriding Branch's continueUseActivity

### DIFF
--- a/src/ios/AppDelegateCordovaCall.m
+++ b/src/ios/AppDelegateCordovaCall.m
@@ -5,27 +5,29 @@
 
 @implementation AppDelegate (CordovaCall)
 
-- (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray *restorableObjects))restorationHandler
-{
-    INInteraction *interaction = userActivity.interaction;
-    INIntent *intent = interaction.intent;
-    BOOL isVideo = [intent isKindOfClass:[INStartVideoCallIntent class]];
-    INPerson *contact;
-    if(isVideo) {
-        INStartVideoCallIntent *startCallIntent = (INStartVideoCallIntent *)intent;
-        contact = startCallIntent.contacts.firstObject;
-    } else {
-        INStartAudioCallIntent *startCallIntent = (INStartAudioCallIntent *)intent;
-        contact = startCallIntent.contacts.firstObject;
-    }
-    INPersonHandle *personHandle = contact.personHandle;
-    NSString *callId = personHandle.value;
-    NSString *callName = [[NSUserDefaults standardUserDefaults] stringForKey:callId];
-    if(!callName) {
-        callName = callId;
-    }
-    NSDictionary *intentInfo = @{ @"callName" : callName, @"callId" : callId, @"isVideo" : isVideo?@YES:@NO};
-    [[NSNotificationCenter defaultCenter] postNotificationName:@"RecentsCallNotification" object:intentInfo];
-    return YES;
-}
+// Comment out the following as it's overriding continueUserActivity in the Branch plugin
+// Have to implement swizzle via cordova-plugin-ios-app-delegate-events but Branch's plugin has a custom declaration of continueUserActivity that gets called when not intended.
+// - (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray *restorableObjects))restorationHandler
+// {
+//     INInteraction *interaction = userActivity.interaction;
+//     INIntent *intent = interaction.intent;
+//     BOOL isVideo = [intent isKindOfClass:[INStartVideoCallIntent class]];
+//     INPerson *contact;
+//     if(isVideo) {
+//         INStartVideoCallIntent *startCallIntent = (INStartVideoCallIntent *)intent;
+//         contact = startCallIntent.contacts.firstObject;
+//     } else {
+//         INStartAudioCallIntent *startCallIntent = (INStartAudioCallIntent *)intent;
+//         contact = startCallIntent.contacts.firstObject;
+//     }
+//     INPersonHandle *personHandle = contact.personHandle;
+//     NSString *callId = personHandle.value;
+//     NSString *callName = [[NSUserDefaults standardUserDefaults] stringForKey:callId];
+//     if(!callName) {
+//         callName = callId;
+//     }
+//     NSDictionary *intentInfo = @{ @"callName" : callName, @"callId" : callId, @"isVideo" : isVideo?@YES:@NO};
+//     [[NSNotificationCenter defaultCenter] postNotificationName:@"RecentsCallNotification" object:intentInfo];
+//     return YES;
+// }
 @end


### PR DESCRIPTION
`continueUserActivity` can only be declared once, but both Branch and Callkit declares it. Callkit is installed last so it overrides and executes when the app resumes from deeplink. Then crashes since it's running when not being intended and lacks conditional code to early return if not `INStartVideoCallIntent` or `INStartAudioCallIntent`.

I've tried to implement "[swizzle](https://github.com/dpa99c/cordova-plugin-ios-app-delegate-events)" for all references to `continueUserActivity`, however it's not straightforward since Branch declares a custom function called `continueUserActivity` that gets executed by swizzle despite having a different signature. Can't rename that custom function since it's being called internally by something.

This code is probably related to starting a call from the native phone recents, not something we're using atm.