### PR TITLE
implement cancelling incoming call

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-callkit",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "description": "Cordova plugin that lets you use iOS CallKit UI (with PushKit) and Android ConnectionService UI",
   "cordova": {
     "id": "cordova-plugin-callkit",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="cordova-plugin-callkit" version="1.1.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="cordova-plugin-callkit" version="1.1.1" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>Cordova CallKit</name>
 
     <js-module name="VoIPPushNotification" src="www/VoIPPushNotification.js">

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -644,7 +644,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 
     NSArray<CXCall *> *calls = self.callController.callObserver.calls;
     CDVPluginResult* pluginResult = nil;
-    if([calls count] == 1) {
+    if([calls count] == 1 && !calls[0].hasConnected) {
         [self.provider reportCallWithUUID:calls[0].UUID endedAtDate:nil reason:CXCallEndedReasonRemoteEnded];
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"dismissRingingCall event called successfully"];
     } else {

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -17,7 +17,6 @@ BOOL monitorAudioRouteChange = NO;
 BOOL enableDTMF = NO;
 PKPushRegistry *_voipRegistry;
 
-BOOL isCancelPush = NO;
 NSString* callBackUrl;
 NSString* callId;
 NSDictionary* callData;
@@ -224,26 +223,18 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         callUpdate.supportsUngrouping = NO;
         callUpdate.supportsHolding = NO;
         callUpdate.supportsDTMF = enableDTMF;
-        if (!isCancelPush) {
-            [self.provider reportNewIncomingCallWithUUID:callUUID update:callUpdate completion:^(NSError * _Nullable error) {
-                if(error == nil) {
-                    [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Incoming call successful"] callbackId:command.callbackId];
-                } else {
-                    [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:[error localizedDescription]] callbackId:command.callbackId];
-                }
-            }];
-            for (id callbackId in callbackIds[@"receiveCall"]) {
-                CDVPluginResult* pluginResult = nil;
-                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"receiveCall event called successfully"];
-                [pluginResult setKeepCallbackAsBool:YES];
-                [self.commandDelegate sendPluginResult:pluginResult callbackId:callbackId];
+        [self.provider reportNewIncomingCallWithUUID:callUUID update:callUpdate completion:^(NSError * _Nullable error) {
+            if(error == nil) {
+                [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Incoming call successful"] callbackId:command.callbackId];
+            } else {
+                [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:[error localizedDescription]] callbackId:command.callbackId];
             }
-        } else {
-            NSArray<CXCall *> *calls = self.callController.callObserver.calls;
-            if([calls count] == 1) {
-                [self.provider reportCallWithUUID:calls[0].UUID endedAtDate:nil reason:CXCallEndedReasonRemoteEnded];
-            }
-            
+        }];
+        for (id callbackId in callbackIds[@"receiveCall"]) {
+            CDVPluginResult* pluginResult = nil;
+            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"receiveCall event called successfully"];
+            [pluginResult setKeepCallbackAsBool:YES];
+            [self.commandDelegate sendPluginResult:pluginResult callbackId:callbackId];
         }
     } else {
         [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Caller id can't be empty"] callbackId:command.callbackId];
@@ -532,7 +523,6 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     if([callbackIds[@"sendCall"] count] == 0) {
         pendingCallFromRecents = callData;
     }
-    //[action fail];
 }
 
 - (void)provider:(CXProvider *)provider didActivateAudioSession:(AVAudioSession *)audioSession
@@ -552,23 +542,12 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     [self setupAudioSession];
     [action fulfill];
 
-    // Notify Webhook that Native Call has been Answered
-    // NSURL *statusUpdateUrl = [NSURL URLWithString:[NSString stringWithFormat:@"%@?id=%@&input=%@", callBackUrl, callId, @"pickup"]];
-    // NSURLSession *session = [NSURLSession sharedSession];
-    // [[session dataTaskWithURL:statusUpdateUrl
-    //           completionHandler:^(NSData *statusUpdateData,
-    //                               NSURLResponse *statusUpdateResponse,
-    //                               NSError *statusUpdateError) {
-    //             // handle response
-    // }] resume];
-
     if ([callbackIds[@"answer"] count] == 0) {
         // callbackId for event not registered, add to pending to trigger on registration
         [pendingCallResponses addObject:PENDING_RESPONSE_ANSWER];
     } else {
         [self triggerCordovaEventForCallResponse:@"answer"];
     }
-    //[action fail];
 }
 
 - (void)provider:(CXProvider *)provider performEndCallAction:(CXEndCallAction *)action
@@ -584,18 +563,6 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
                 [self.commandDelegate sendPluginResult:pluginResult callbackId:callbackId];
             }
         } else {
-            // Notify Webhook that Native Call has been Declined
-            // if (!isCancelPush) {
-            //     NSURL *statusUpdateUrl = [NSURL URLWithString:[NSString stringWithFormat:@"%@?id=%@&input=%@", callBackUrl, callId, @"declined_callee"]];
-            //     NSURLSession *session = [NSURLSession sharedSession];
-            //     [[session dataTaskWithURL:statusUpdateUrl
-            //             completionHandler:^(NSData *statusUpdateData,
-            //                                 NSURLResponse *statusUpdateResponse,
-            //                                 NSError *statusUpdateError) {
-            //                 // handle response
-            //     }] resume];
-            // }
-
             if ([callbackIds[@"reject"] count] == 0) {
                 // callbackId for event not registered, add to pending to trigger on registration
                 [pendingCallResponses addObject:PENDING_RESPONSE_REJECT];
@@ -606,7 +573,6 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     }
     monitorAudioRouteChange = NO;
     [action fulfill];
-    //[action fail];
 }
 
 - (void)triggerCordovaEventForCallResponse:(NSString*) response {
@@ -671,6 +637,22 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         [self.commandDelegate sendPluginResult:pluginResult callbackId:callbackId];
     }
 }
+
+- (void) dismissRingingCall:(CDVInvokedUrlCommand*)command
+{
+    [self logMessage:@"dismissRingingCall"];
+
+    NSArray<CXCall *> *calls = self.callController.callObserver.calls;
+    CDVPluginResult* pluginResult = nil;
+    if([calls count] == 1) {
+        [self.provider reportCallWithUUID:calls[0].UUID endedAtDate:nil reason:CXCallEndedReasonRemoteEnded];
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"dismissRingingCall event called successfully"];
+    } else {
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+    }
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
 // PushKit
 - (void)init:(CDVInvokedUrlCommand*)command
 {
@@ -738,22 +720,6 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     callBackUrl = [caller valueForKey:@"CallbackUrl"];
     callId = [caller valueForKey:@"ConnectionId"];
     callData = data;
-    if ([[caller valueForKey:@"CancelPush"] isEqualToString:@"true"]) {
-        isCancelPush = YES;
-    } else {
-        isCancelPush = NO;
-    }
-    if (!isCancelPush) {
-        // Notify Webhook that VOIP Push Has been received and app is started
-        // NSURL *statusUpdateUrl = [NSURL URLWithString:[NSString stringWithFormat:@"%@?id=%@&input=%@", callBackUrl, callId, @"connected"]];
-        // NSURLSession *session = [NSURLSession sharedSession];
-        // [[session dataTaskWithURL:statusUpdateUrl
-        //           completionHandler:^(NSData *statusUpdateData,
-        //                               NSURLResponse *statusUpdateResponse,
-        //                               NSError *statusUpdateError) {
-        //             // handle response
-        // }] resume];
-    }
 
     [self receiveCall:newCommand];
     @try {

--- a/www/CordovaCall.js
+++ b/www/CordovaCall.js
@@ -98,3 +98,7 @@ exports.on = function(e, f) {
 exports.checkCallPermission = function(error) {
     exec(null, error, "CordovaCall", "checkCallPermission", []);
 };
+
+exports.dismissRingingCall = function(success) {
+    exec(success, null, "CordovaCall", "dismissRingingCall", []);
+}


### PR DESCRIPTION
Remove legacy cancel push and webhook code.

Take the relevant dismiss code of `[self.provider reportCallWithUUID:calls[0].UUID endedAtDate:nil reason:CXCallEndedReasonRemoteEnded];` and expose it to JS.

Don't fail if there isn't a call to cancel, don't cancel ongoing calls.