### PR TITLE
Native logging + Native Websocket + JS KeepAlive

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -56,11 +56,17 @@
         </config-file>
 
         <header-file src="src/ios/CordovaCall.h" />
-
         <source-file src="src/ios/CordovaCall.m" />
         <source-file src="src/ios/AppDelegateCordovaCall.m" />
+        <header-file src="src/ios/WebSocketAdvanced.h" />
+        <source-file src="src/ios/WebSocketAdvanced.m" />
 
         <framework src="PushKit.framework" />
         <framework src="CallKit.framework" />
+        <podspec>
+            <pods use-frameworks="true">
+                <pod name="SocketRocket" spec="0.7.0" />
+            </pods>
+        </podspec>
     </platform>
 </plugin>

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -115,6 +115,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
       NSTimeInterval bufferDuration = .005;
       [sessionInstance setPreferredIOBufferDuration:bufferDuration error:nil];
       [sessionInstance setPreferredSampleRate:44100 error:nil];
+    //   [sessionInstance setActive:YES error:nil];
       [self logMessage:@"Configuring Audio"];
     }
     @catch (NSException *exception) {
@@ -628,6 +629,15 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
     }
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
+- (void) log:(CDVInvokedUrlCommand*)command
+{
+    CDVPluginResult* pluginResult = nil;
+    NSString* message = [command.arguments objectAtIndex:0];
+    if (message != nil && [message length] > 0) {
+        [self logMessage:message];
+    }
 }
 
 // PushKit

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -279,11 +279,11 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     CDVPluginResult* pluginResult = nil;
     NSArray<CXCall *> *calls = self.callController.callObserver.calls;
 
-    if([calls count] == 1) {
+    if([calls count] == 1 && !calls[0].hasConnected) {
         [self.provider reportOutgoingCallWithUUID:calls[0].UUID connectedAtDate:nil];
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Call connected successfully"];
     } else {
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"No call exists for you to connect"];
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"No call exists for you to connect"];
     }
 
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
@@ -292,6 +292,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 - (void)endCall:(CDVInvokedUrlCommand*)command
 {
     [self logMessage:@"endCall"];
+    [self stopKeepAlive:command];
     CDVPluginResult* pluginResult = nil;
     NSArray<CXCall *> *calls = self.callController.callObserver.calls;
 
@@ -566,6 +567,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 - (void)provider:(CXProvider *)provider performEndCallAction:(CXEndCallAction *)action
 {
     [self logMessage:@"performEndCallAction"];
+    [self stopKeepAlive:nil];
     NSArray<CXCall *> *calls = self.callController.callObserver.calls;
     if([calls count] == 1) {
         if(calls[0].hasConnected) {
@@ -650,7 +652,6 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 
 - (void) log:(CDVInvokedUrlCommand*)command
 {
-    CDVPluginResult* pluginResult = nil;
     NSString* message = [command.arguments objectAtIndex:0];
     if (message != nil && [message length] > 0) {
         [self logMessage:message];
@@ -674,10 +675,9 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 
 - (void) stopKeepAlive:(CDVInvokedUrlCommand*)command
 {
-    [self logMessage:@"stopKeepAlive"];
-    
     // Invalidate the timer
     if (keepAlive) {
+        [self logMessage:@"stopKeepAlive"];
         [keepAlive invalidate];
         keepAlive = nil;
     }

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -25,6 +25,7 @@ NSDictionary* callData;
 BOOL isMutedState;
 NSTimer *keepAlive;
 NSMutableDictionary* webSockets;
+UIBackgroundTaskIdentifier bgTask;
 
 NSMutableArray* pendingCallResponses;
 NSString* const PENDING_RESPONSE_ANSWER = @"pendingResponseAnswer";
@@ -296,7 +297,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 - (void)endCall:(CDVInvokedUrlCommand*)command
 {
     [self logMessage:@"endCall"];
-    [self stopKeepAlive:command];
+    [self stopKeepAlive:nil];
     CDVPluginResult* pluginResult = nil;
     NSArray<CXCall *> *calls = self.callController.callObserver.calls;
 
@@ -552,19 +553,14 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     }
 
     UIApplication *app = [UIApplication sharedApplication];
-    __block UIBackgroundTaskIdentifier bgTask = UIBackgroundTaskInvalid;
     bgTask = [app beginBackgroundTaskWithExpirationHandler:^{
-        // End the background task after 30s
-        [app endBackgroundTask:bgTask];
-        bgTask = UIBackgroundTaskInvalid;
+        // Have iOS kill the background task after 30s, we don't want this to run
+        [self _endBackgroundTask];
     }];
     
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(29 * NSEC_PER_SEC)), dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         [self logMessage:@"29 seconds elapsed, ending background task"];
-
-        // End the background task
-        [app endBackgroundTask:bgTask];
-        bgTask = UIBackgroundTaskInvalid;
+        [self _endBackgroundTask];
     });
 }
 
@@ -675,7 +671,8 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     [self logMessage:@"keepAlive"];
     
     // Invalidate any existing timer
-    [self stopKeepAlive:command];
+    [keepAlive invalidate];
+    keepAlive = nil;
     
     [self _keepWKWebViewActive:nil];
     keepAlive = [NSTimer scheduledTimerWithTimeInterval:0.2
@@ -687,11 +684,25 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 
 - (void) stopKeepAlive:(CDVInvokedUrlCommand*)command
 {
-    if (keepAlive) {
-        [self logMessage:@"stopKeepAlive"];
-        [keepAlive invalidate];
-        keepAlive = nil;
-    }
+  if (keepAlive) {
+    [self logMessage:@"stopKeepAlive"];
+    [keepAlive invalidate];
+    keepAlive = nil;
+    // End background task also
+    [self _endBackgroundTask];
+  }
+}
+
+- (void)_endBackgroundTask;
+{
+  if (bgTask != UIBackgroundTaskInvalid) {
+    [self logMessage:@"Ending Background Task"];
+    UIApplication *app = [UIApplication sharedApplication];
+    [app endBackgroundTask:bgTask];
+    bgTask = UIBackgroundTaskInvalid;
+  }
+  // Stop keepAlive just in case we don't call it from JS
+  [self stopKeepAlive:nil];
 }
 
 - (void)wsConnect:(CDVInvokedUrlCommand*)command;

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -1,6 +1,8 @@
 #import "CordovaCall.h"
 #import <Cordova/CDV.h>
 #import <AVFoundation/AVFoundation.h>
+#import "WebSocketAdvanced.h"
+#import <SocketRocket/SocketRocket.h>
 
 @implementation CordovaCall
 
@@ -22,6 +24,7 @@ NSString* callId;
 NSDictionary* callData;
 BOOL isMutedState;
 NSTimer *keepAlive;
+NSMutableDictionary* webSockets;
 
 NSMutableArray* pendingCallResponses;
 NSString* const PENDING_RESPONSE_ANSWER = @"pendingResponseAnswer";
@@ -79,6 +82,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     
     // Read VoIPPushToken from UserDefaults
     self.VoIPPushToken = [[NSUserDefaults standardUserDefaults] stringForKey:KEY_VOIP_PUSH_TOKEN];
+    webSockets = [[NSMutableDictionary alloc] init];
 }
 
 // CallKit - Interface
@@ -688,6 +692,65 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         [keepAlive invalidate];
         keepAlive = nil;
     }
+}
+
+- (void)wsConnect:(CDVInvokedUrlCommand*)command;
+{
+    NSDictionary* wsOptions = [command argumentAtIndex:0];
+    WebSocketAdvanced* ws = [[WebSocketAdvanced alloc] initWithOptions:wsOptions
+                                                       commandDelegate:self.commandDelegate
+                                                       callbackId:command.callbackId];
+    [webSockets setObject:ws forKey:ws.webSocketId];
+}
+
+- (void)wsAddListeners:(CDVInvokedUrlCommand*)command;
+{
+    NSString* webSocketId = [command argumentAtIndex:0];
+    BOOL flushRecvBuffer = [command argumentAtIndex:1];
+    WebSocketAdvanced* ws = [webSockets valueForKey:webSocketId];
+    if (ws != nil) {
+        [ws wsAddListeners:command.callbackId flushRecvBuffer:flushRecvBuffer];
+    }
+}
+
+- (void)wsSend:(CDVInvokedUrlCommand*)command;
+{
+    NSString* webSocketId = [command argumentAtIndex:0];
+    NSString* message = [command argumentAtIndex:1];
+    WebSocketAdvanced* ws = [webSockets valueForKey:webSocketId];
+    if (ws != nil) {
+        [ws wsSendMessage:message];
+    }
+}
+
+- (void)wsClose:(CDVInvokedUrlCommand*)command;
+{
+    NSString* webSocketId = [command argumentAtIndex:0];
+    NSNumber* code = [command argumentAtIndex:1];
+    NSString* reason = [command argumentAtIndex:2];
+    WebSocketAdvanced* ws = [webSockets valueForKey:webSocketId];
+    if (ws != nil) {
+        [ws wsClose:code.integerValue reason:reason];
+    }
+}
+
+- (void)dealloc;
+{
+    [self _closeAllSockets];
+}
+
+- (void)onReset;
+{
+    [super onReset];
+}
+
+- (void)_closeAllSockets;
+{
+    for(id wsId in webSockets) {
+        WebSocketAdvanced* ws = [webSockets objectForKey:wsId];
+        [ws wsClose];
+    }
+    [webSockets removeAllObjects];
 }
 
 // PushKit

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -665,8 +665,13 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     // Invalidate any existing timer
     [self stopKeepAlive:command];
 
-    // Start a new timer that fires every second
-    keepAlive = [NSTimer scheduledTimerWithTimeInterval:1.0 repeats:YES block:^(NSTimer * _Nonnull timer) {
+    // Immediately send the first callback
+    CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:[[NSDate date] description]];
+    [pluginResult setKeepCallbackAsBool:YES];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+
+    // Start a new timer that fires every 100ms as Answer -> SIP Connect is ~1s duration
+    keepAlive = [NSTimer scheduledTimerWithTimeInterval:0.1 repeats:YES block:^(NSTimer * _Nonnull timer) {
         CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:[[NSDate date] description]];
         [pluginResult setKeepCallbackAsBool:YES];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -116,7 +116,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
       NSTimeInterval bufferDuration = .005;
       [sessionInstance setPreferredIOBufferDuration:bufferDuration error:nil];
       [sessionInstance setPreferredSampleRate:44100 error:nil];
-      [sessionInstance setActive:YES error:nil];
+    //   [sessionInstance setActive:YES error:nil];
       [self logMessage:@"Configuring Audio"];
     }
     @catch (NSException *exception) {
@@ -658,29 +658,31 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     }
 }
 
+-(void) _keepWKWebViewActive:(NSTimer*) timer {
+    if ([self.webView isKindOfClass:[WKWebView class]]) {
+        [self logMessage:@"keepingAlive"];
+        WKWebView *wkWebView = (WKWebView *)self.webView;
+        [wkWebView evaluateJavaScript:@"1+1" completionHandler:nil];
+    }
+}
+
 - (void) keepAlive:(CDVInvokedUrlCommand*)command
 {
     [self logMessage:@"keepAlive"];
     
     // Invalidate any existing timer
     [self stopKeepAlive:command];
-
-    // Immediately send the first callback
-    CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:[[NSDate date] description]];
-    [pluginResult setKeepCallbackAsBool:YES];
-    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
-
-    // Start a new timer that fires every 100ms as Answer -> SIP Connect is ~1s duration
-    keepAlive = [NSTimer scheduledTimerWithTimeInterval:0.1 repeats:YES block:^(NSTimer * _Nonnull timer) {
-        CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:[[NSDate date] description]];
-        [pluginResult setKeepCallbackAsBool:YES];
-        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
-    }];
+    
+    [self _keepWKWebViewActive:nil];
+    keepAlive = [NSTimer scheduledTimerWithTimeInterval:0.2
+                                     target:self
+                                     selector:@selector(_keepWKWebViewActive:)
+                                     userInfo:nil
+                                     repeats:YES];
 }
 
 - (void) stopKeepAlive:(CDVInvokedUrlCommand*)command
 {
-    // Invalidate the timer
     if (keepAlive) {
         [self logMessage:@"stopKeepAlive"];
         [keepAlive invalidate];

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -21,6 +21,7 @@ NSString* callBackUrl;
 NSString* callId;
 NSDictionary* callData;
 BOOL isMutedState;
+NSTimer *keepAlive;
 
 NSMutableArray* pendingCallResponses;
 NSString* const PENDING_RESPONSE_ANSWER = @"pendingResponseAnswer";
@@ -115,7 +116,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
       NSTimeInterval bufferDuration = .005;
       [sessionInstance setPreferredIOBufferDuration:bufferDuration error:nil];
       [sessionInstance setPreferredSampleRate:44100 error:nil];
-    //   [sessionInstance setActive:YES error:nil];
+      [sessionInstance setActive:YES error:nil];
       [self logMessage:@"Configuring Audio"];
     }
     @catch (NSException *exception) {
@@ -544,6 +545,22 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     } else {
         [self triggerCordovaEventForCallResponse:@"answer"];
     }
+
+    UIApplication *app = [UIApplication sharedApplication];
+    __block UIBackgroundTaskIdentifier bgTask = UIBackgroundTaskInvalid;
+    bgTask = [app beginBackgroundTaskWithExpirationHandler:^{
+        // End the background task after 30s
+        [app endBackgroundTask:bgTask];
+        bgTask = UIBackgroundTaskInvalid;
+    }];
+    
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(29 * NSEC_PER_SEC)), dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        [self logMessage:@"29 seconds elapsed, ending background task"];
+
+        // End the background task
+        [app endBackgroundTask:bgTask];
+        bgTask = UIBackgroundTaskInvalid;
+    });
 }
 
 - (void)provider:(CXProvider *)provider performEndCallAction:(CXEndCallAction *)action
@@ -640,6 +657,32 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     }
 }
 
+- (void) keepAlive:(CDVInvokedUrlCommand*)command
+{
+    [self logMessage:@"keepAlive"];
+    
+    // Invalidate any existing timer
+    [self stopKeepAlive:command];
+
+    // Start a new timer that fires every second
+    keepAlive = [NSTimer scheduledTimerWithTimeInterval:1.0 repeats:YES block:^(NSTimer * _Nonnull timer) {
+        CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:[[NSDate date] description]];
+        [pluginResult setKeepCallbackAsBool:YES];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+    }];
+}
+
+- (void) stopKeepAlive:(CDVInvokedUrlCommand*)command
+{
+    [self logMessage:@"stopKeepAlive"];
+    
+    // Invalidate the timer
+    if (keepAlive) {
+        [keepAlive invalidate];
+        keepAlive = nil;
+    }
+}
+
 // PushKit
 - (void)init:(CDVInvokedUrlCommand*)command
 {
@@ -710,6 +753,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     callData = data;
 
     [self receiveCall:newCommand];
+
     @try {
         NSError * err;
         NSData * jsonData = [NSJSONSerialization dataWithJSONObject:data options:0 error:&err];

--- a/src/ios/WebSocketAdvanced.h
+++ b/src/ios/WebSocketAdvanced.h
@@ -1,0 +1,26 @@
+#import <SocketRocket/SocketRocket.h>
+
+@interface WebSocketAdvanced: NSObject <SRWebSocketDelegate>
+{
+    SRWebSocket* _webSocket;
+    id<CDVCommandDelegate> _commandDelegate;
+    NSString* _callbackId;
+    NSString* _recvCallbackId;
+    NSTimer* _pingTimer;
+    NSTimeInterval _pingInterval;
+    NSInteger _pingCount;
+    NSInteger _pongCount;
+    BOOL _awaitingPong;
+    NSMutableArray* _messageBuffer;
+}
+@property NSString* webSocketId;
+
+- (instancetype)initWithOptions:(NSDictionary*)wsOptions 
+                commandDelegate:(id<CDVCommandDelegate>)commandDelegate
+                callbackId:(NSString*)callbackId;
+- (void)wsAddListeners:(NSString*)recvCallbackId flushRecvBuffer:(BOOL)flushRecvBuffer;
+- (void)wsSendMessage:(NSString*)message;
+- (void)wsClose;
+- (void)wsClose:(NSInteger)code reason:(NSString*)reason;
+
+@end

--- a/src/ios/WebSocketAdvanced.m
+++ b/src/ios/WebSocketAdvanced.m
@@ -1,0 +1,241 @@
+#import <Cordova/CDV.h>
+#import "WebSocketAdvanced.h"
+
+@implementation WebSocketAdvanced
+
+- (instancetype)initWithOptions:(NSDictionary*)wsOptions 
+                commandDelegate:(id<CDVCommandDelegate>)commandDelegate
+                callbackId:(NSString*)callbackId;
+{
+    NSString* wsUrl =           [wsOptions valueForKey:@"url"];
+    NSNumber* timeout =         [wsOptions valueForKey:@"timeout"];
+    NSNumber* pingInterval =    [wsOptions valueForKey:@"pingInterval"];
+    NSDictionary* wsHeaders =   [wsOptions valueForKey:@"headers"];
+    BOOL acceptAllCerts =       [wsOptions valueForKey:@"acceptAllCerts"];
+
+    _messageBuffer =            [[NSMutableArray alloc] init];
+
+    NSTimeInterval timeoutInterval = timeout ? (timeout.doubleValue / 1000) : 0;
+    _pingInterval = pingInterval ? (pingInterval.doubleValue / 1000) : 0;
+    
+    self.webSocketId = [[NSUUID UUID] UUIDString];
+
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:wsUrl]
+                                                        cachePolicy:NSURLRequestUseProtocolCachePolicy
+                                                        timeoutInterval:timeoutInterval];
+
+    for(id key in wsHeaders) {
+        [request addValue:[wsHeaders objectForKey:key] forHTTPHeaderField:key];
+    }
+
+    _webSocket = [[SRWebSocket alloc] initWithURLRequest:request
+                                      protocols:nil
+                                      allowsUntrustedSSLCertificates:acceptAllCerts];
+    
+    _webSocket.delegate = self;
+    _commandDelegate = commandDelegate;
+    _callbackId = callbackId;
+
+    _pingCount = 0;
+    _pongCount = 0;
+    _awaitingPong = NO;
+
+    [_commandDelegate runInBackground:^{
+        [_webSocket open];
+    }];
+    return self;
+}
+
+- (void)wsAddListeners:(NSString*)recvCallbackId flushRecvBuffer:(BOOL)flushRecvBuffer;
+{
+    _recvCallbackId = recvCallbackId;
+    
+    if([_messageBuffer count] > 0 && flushRecvBuffer) {
+        for(CDVPluginResult* message in _messageBuffer) {
+            [_commandDelegate sendPluginResult:message callbackId:recvCallbackId];
+        }
+    }
+    [_messageBuffer removeAllObjects];
+}
+
+- (void)wsSendMessage:(NSString*)message;
+{
+    if (_webSocket != nil) {
+        [_webSocket send:message];
+    }
+}
+
+- (void)wsClose;
+{
+    if (_webSocket != nil) {
+        [_webSocket close];
+    }
+}
+
+- (void)wsClose:(NSInteger)code reason:(NSString*)reason;
+{
+    if (_webSocket != nil) {
+        [_webSocket closeWithCode:code reason:reason];
+    }
+}
+
+- (void)wsSendPing:(NSData*)data;
+{
+    if (_webSocket != nil) {
+        NSInteger failedPing = _awaitingPong ? _pingCount : -1;
+
+        if (failedPing != -1) {
+            NSMutableDictionary* errorResult = [[NSMutableDictionary alloc] init];
+            NSNumber* code = [NSNumber numberWithInteger:SRStatusCodeAbnormal];
+            NSString* reason = [NSString stringWithFormat:@"Last pong was not received for ping #%ld", failedPing];
+            if (_recvCallbackId != nil) {
+                [errorResult setValue:self.webSocketId  forKey:@"webSocketId"];
+                [errorResult setValue:code              forKey:@"code"];
+                [errorResult setValue:reason            forKey:@"exception"];
+                [errorResult setValue:@"onFail"         forKey:@"callbackMethod"];
+                CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:errorResult];
+                [pluginResult setKeepCallbackAsBool:YES];
+                [_commandDelegate sendPluginResult:pluginResult callbackId:_recvCallbackId];
+            }
+            if (_pingTimer != nil) {
+                [_pingTimer invalidate];
+                _pingTimer = nil;
+            }
+            _webSocket = nil;
+            return;
+        }
+        _pingCount++;
+        _awaitingPong = YES;
+        @try {
+            [_webSocket sendPing:data error:NULL];
+        }
+        @catch (NSException *exception) {
+            // Swallow exception 
+            // This fixes race condition where websocket is destroyed and ping is sent to nowhere, what crashes app
+        }
+        NSLog(@"Sent ping #%ld", _pingCount);
+    }
+}
+
+- (void)wsPingTimer:(NSTimer*)timer;
+{
+    // Timer fired, send ping
+    [self wsSendPing:nil];
+}
+
+#pragma mark - SRWebSocketDelegate
+
+- (void)webSocketDidOpen:(SRWebSocket*)webSocket;
+{
+    NSMutableDictionary* successResult = [[NSMutableDictionary alloc] init];
+    NSNumber* code = [NSNumber numberWithInteger:SRStatusCodeNormal];
+
+    [successResult setValue:self.webSocketId forKey:@"webSocketId"];
+    [successResult setValue:code             forKey:@"code"];
+
+    CDVPluginResult* pluginResult =[CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:successResult];
+    [_commandDelegate sendPluginResult:pluginResult callbackId:_callbackId];
+
+    if (_pingInterval > 0) { 
+        NSLog(@"Setting up ping timer with ping interval: %f", _pingInterval);
+        _pingTimer = [NSTimer scheduledTimerWithTimeInterval:_pingInterval
+                              target:self selector:@selector(wsPingTimer:)
+                              userInfo:nil repeats:YES];
+    }
+}
+
+- (void)webSocket:(SRWebSocket*)webSocket didFailWithError:(NSError*)error;
+{
+    NSMutableDictionary* errorResult = [[NSMutableDictionary alloc] init];
+    NSNumber* code = [NSNumber numberWithInteger:SRStatusCodeAbnormal];
+    
+    [errorResult setValue:self.webSocketId           forKey:@"webSocketId"];
+    [errorResult setValue:code                       forKey:@"code"];
+    [errorResult setValue:error.localizedDescription forKey:@"exception"];
+
+    @try {
+        CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:errorResult];
+        [_commandDelegate sendPluginResult:pluginResult callbackId:_callbackId];
+    }
+    @catch (NSException *exception) {
+        // Swallow exception
+    }
+
+    if (_recvCallbackId != nil) {
+        [errorResult setValue:@"onFail" forKey:@"callbackMethod"];
+        CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:errorResult];
+        [pluginResult setKeepCallbackAsBool:YES];
+        [_commandDelegate sendPluginResult:pluginResult callbackId:_recvCallbackId];
+    }
+
+    _webSocket = nil;
+
+    if (_pingTimer != nil) {
+        [_pingTimer invalidate];
+        _pingTimer = nil;
+    }
+}
+
+- (void)webSocket:(SRWebSocket*)webSocket didReceiveMessage:(id)message;
+{
+    NSMutableDictionary* callbackResult = [[NSMutableDictionary alloc] init];
+    [callbackResult setValue:@"onMessage"     forKey:@"callbackMethod"];
+    [callbackResult setValue:self.webSocketId forKey:@"webSocketId"];
+    [callbackResult setValue:message          forKey:@"message"];
+    
+    CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:callbackResult];
+    [pluginResult setKeepCallbackAsBool:YES];
+
+    if (_recvCallbackId != nil) {
+        [_commandDelegate sendPluginResult:pluginResult callbackId:_recvCallbackId];
+    }
+    else {
+        [_messageBuffer addObject:pluginResult];
+    }
+}
+
+- (void)webSocket:(SRWebSocket*)webSocket didCloseWithCode:(NSInteger)code reason:(NSString*)reason wasClean:(BOOL)wasClean;
+{
+    NSMutableDictionary* callbackResult = [[NSMutableDictionary alloc] init];
+    NSNumber* c = [NSNumber numberWithInteger:code];
+
+    [callbackResult setValue:self.webSocketId forKey:@"webSocketId"];
+    [callbackResult setValue:c                forKey:@"code"];
+    [callbackResult setValue:reason           forKey:@"reason"];
+
+    @try {
+        CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:callbackResult];
+        [_commandDelegate sendPluginResult:pluginResult callbackId:_callbackId];
+    }
+    @catch (NSException *exception) {
+        // Swallow exception
+    }
+    
+    if (_recvCallbackId != nil) {
+        [callbackResult setValue:@"onClose" forKey:@"callbackMethod"];
+        CDVPluginResult* pluginResult =[CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:callbackResult];
+        [pluginResult setKeepCallbackAsBool:YES];
+        [_commandDelegate sendPluginResult:pluginResult callbackId:_recvCallbackId];
+    }
+
+    _webSocket = nil;
+
+    if (_pingTimer != nil) {
+        [_pingTimer invalidate];
+        _pingTimer = nil;
+    }
+}
+
+- (void)webSocket:(SRWebSocket*)webSocket didReceivePong:(nullable NSData*)pongData;
+{
+    _pongCount++;
+    _awaitingPong = NO;
+    NSLog(@"Received pong #%ld", _pongCount);
+}
+
+- (BOOL)webSocketShouldConvertTextFrameToString:(SRWebSocket*)webSocket;
+{
+    return YES;
+}
+
+@end

--- a/www/CordovaCall.js
+++ b/www/CordovaCall.js
@@ -114,3 +114,29 @@ exports.keepAlive = function(callback) {
 exports.stopKeepAlive = function() {
     exec(null, null, "CordovaCall", "stopKeepAlive", []);
 }
+
+exports.wsConnect = function (wsOptions, listener, success, error) {
+  if (listener === undefined) {
+    listener = function (data) {
+      console.log(data);
+    };
+  }
+
+  var connectSuccess = function (data) {
+    if (success !== undefined && typeof success === "function") {
+      success(data);
+    }
+    var flushRecvBuffer = true;
+    exec(listener, listener, "CordovaCall", 'wsAddListeners', [data.webSocketId, flushRecvBuffer]);
+  };
+
+  exec(connectSuccess, error, "CordovaCall", 'wsConnect', [wsOptions]);
+};
+
+exports.wsSend = function (wsId, message) {
+  exec(null, null, "CordovaCall", 'wsSend', [wsId, message]);
+};
+
+exports.wsClose = function (wsId, code, reason) {
+  exec(null, null, "CordovaCall", 'wsClose', [wsId, code, reason]);
+};

--- a/www/CordovaCall.js
+++ b/www/CordovaCall.js
@@ -1,118 +1,118 @@
 var exec = require('cordova/exec');
 
-exports.setAppName = function(appName, success, error) {
-    exec(success, error, "CordovaCall", "setAppName", [appName]);
+exports.setAppName = function (appName, success, error) {
+  exec(success, error, "CordovaCall", "setAppName", [appName]);
 };
 
-exports.setIcon = function(iconName, success, error) {
-    exec(success, error, "CordovaCall", "setIcon", [iconName]);
+exports.setIcon = function (iconName, success, error) {
+  exec(success, error, "CordovaCall", "setIcon", [iconName]);
 };
 
-exports.setRingtone = function(ringtoneName, success, error) {
-    exec(success, error, "CordovaCall", "setRingtone", [ringtoneName]);
+exports.setRingtone = function (ringtoneName, success, error) {
+  exec(success, error, "CordovaCall", "setRingtone", [ringtoneName]);
 };
 
-exports.setIncludeInRecents = function(value, success, error) {
-    if(typeof value == "boolean") {
-      exec(success, error, "CordovaCall", "setIncludeInRecents", [value]);
-    } else {
-      error("Value Must Be True Or False");
-    }
+exports.setIncludeInRecents = function (value, success, error) {
+  if (typeof value == "boolean") {
+    exec(success, error, "CordovaCall", "setIncludeInRecents", [value]);
+  } else {
+    error("Value Must Be True Or False");
+  }
 };
 
-exports.setDTMFState = function(value, success, error) {
-    if(typeof value == "boolean") {
-      exec(success, error, "CordovaCall", "setDTMFState", [value]);
-    } else {
-      error("Value Must Be True Or False");
-    }
+exports.setDTMFState = function (value, success, error) {
+  if (typeof value == "boolean") {
+    exec(success, error, "CordovaCall", "setDTMFState", [value]);
+  } else {
+    error("Value Must Be True Or False");
+  }
 };
 
-exports.setVideo = function(value, success, error) {
-    if(typeof value == "boolean") {
-      exec(success, error, "CordovaCall", "setVideo", [value]);
-    } else {
-      error("Value Must Be True Or False");
-    }
+exports.setVideo = function (value, success, error) {
+  if (typeof value == "boolean") {
+    exec(success, error, "CordovaCall", "setVideo", [value]);
+  } else {
+    error("Value Must Be True Or False");
+  }
 };
 
-exports.receiveCall = function(from, id, success, error) {
-    if(typeof id == "function") {
-      error = success;
-      success = id;
-      id = undefined;
-    } else if(id) {
-      id = id.toString();
-    }
-    exec(success, error, "CordovaCall", "receiveCall", [from, id]);
+exports.receiveCall = function (from, id, success, error) {
+  if (typeof id == "function") {
+    error = success;
+    success = id;
+    id = undefined;
+  } else if (id) {
+    id = id.toString();
+  }
+  exec(success, error, "CordovaCall", "receiveCall", [from, id]);
 };
 
-exports.sendCall = function(to, id, success, error) {
-    if(typeof id == "function") {
-      error = success;
-      success = id;
-      id = undefined;
-    } else if(id) {
-      id = id.toString();
-    }
-    exec(success, error, "CordovaCall", "sendCall", [to, id]);
+exports.sendCall = function (to, id, success, error) {
+  if (typeof id == "function") {
+    error = success;
+    success = id;
+    id = undefined;
+  } else if (id) {
+    id = id.toString();
+  }
+  exec(success, error, "CordovaCall", "sendCall", [to, id]);
 };
 
-exports.connectCall = function(success, error) {
-    exec(success, error, "CordovaCall", "connectCall", []);
+exports.connectCall = function (success, error) {
+  exec(success, error, "CordovaCall", "connectCall", []);
 };
 
-exports.endCall = function(success, error) {
-    exec(success, error, "CordovaCall", "endCall", []);
+exports.endCall = function (success, error) {
+  exec(success, error, "CordovaCall", "endCall", []);
 };
 
-exports.mute = function(success, error) {
-    exec(success, error, "CordovaCall", "mute", []);
+exports.mute = function (success, error) {
+  exec(success, error, "CordovaCall", "mute", []);
 };
 
-exports.unmute = function(success, error) {
-    exec(success, error, "CordovaCall", "unmute", []);
+exports.unmute = function (success, error) {
+  exec(success, error, "CordovaCall", "unmute", []);
 };
 
-exports.speakerOn = function(success, error) {
-    exec(success, error, "CordovaCall", "speakerOn", []);
+exports.speakerOn = function (success, error) {
+  exec(success, error, "CordovaCall", "speakerOn", []);
 };
 
-exports.speakerOff = function(success, error) {
-    exec(success, error, "CordovaCall", "speakerOff", []);
+exports.speakerOff = function (success, error) {
+  exec(success, error, "CordovaCall", "speakerOff", []);
 };
 
-exports.callNumber = function(to, success, error) {
-    exec(success, error, "CordovaCall", "callNumber", [to]);
+exports.callNumber = function (to, success, error) {
+  exec(success, error, "CordovaCall", "callNumber", [to]);
 };
 
-exports.on = function(e, f) {
-    var success = function(message) {
-      f(message);
-    };
-    var error = function() {
-    };
-    exec(success, error, "CordovaCall", "registerEvent", [e]);
+exports.on = function (e, f) {
+  var success = function (message) {
+    f(message);
+  };
+  var error = function () {
+  };
+  exec(success, error, "CordovaCall", "registerEvent", [e]);
 };
 
-exports.checkCallPermission = function(error) {
-    exec(null, error, "CordovaCall", "checkCallPermission", []);
+exports.checkCallPermission = function (error) {
+  exec(null, error, "CordovaCall", "checkCallPermission", []);
 };
 
-exports.dismissRingingCall = function(success) {
-    exec(success, null, "CordovaCall", "dismissRingingCall", []);
+exports.dismissRingingCall = function (success) {
+  exec(success, null, "CordovaCall", "dismissRingingCall", []);
 }
 
-exports.log = function(message) {
-    exec(null, null, "CordovaCall", "log", [message]);
+exports.log = function (message) {
+  exec(null, null, "CordovaCall", "log", [message]);
 }
 
-exports.keepAlive = function(callback) {
-    exec(callback, null, "CordovaCall", "keepAlive", []);
+exports.keepAlive = function (callback) {
+  exec(callback, null, "CordovaCall", "keepAlive", []);
 }
 
-exports.stopKeepAlive = function() {
-    exec(null, null, "CordovaCall", "stopKeepAlive", []);
+exports.stopKeepAlive = function () {
+  exec(null, null, "CordovaCall", "stopKeepAlive", []);
 }
 
 exports.wsConnect = function (wsOptions, listener, success, error) {

--- a/www/CordovaCall.js
+++ b/www/CordovaCall.js
@@ -102,3 +102,7 @@ exports.checkCallPermission = function(error) {
 exports.dismissRingingCall = function(success) {
     exec(success, null, "CordovaCall", "dismissRingingCall", []);
 }
+
+exports.log = function(message) {
+    exec(null, null, "CordovaCall", "log", [message]);
+}

--- a/www/CordovaCall.js
+++ b/www/CordovaCall.js
@@ -106,3 +106,11 @@ exports.dismissRingingCall = function(success) {
 exports.log = function(message) {
     exec(null, null, "CordovaCall", "log", [message]);
 }
+
+exports.keepAlive = function(callback) {
+    exec(callback, null, "CordovaCall", "keepAlive", []);
+}
+
+exports.stopKeepAlive = function() {
+    exec(null, null, "CordovaCall", "stopKeepAlive", []);
+}


### PR DESCRIPTION
Adding native level logging, since we can't attach safari when the phone is locked.

Add native websocket to replace AudioCall's SIP WS.
- Code copied from [cordova-plugin-advanced-websocket](https://github.com/HeimgardTechnologiesAS/cordova-plugin-advanced-websocket), can't use that plugin since only `CordovaCall` plugin is spun up when answering from lockscreen.

Add JS level `keepAlive`, ping JS every 200ms to keep it alive for ~30s with a background task. Stops background task and keepAlive once we're done processing the call.