### PR TITLE
[Extra] Handle Custom FCM message on iOS

### DIFF
--- a/src/ios/CordovaCall.h
+++ b/src/ios/CordovaCall.h
@@ -1,6 +1,14 @@
 #import <Cordova/CDV.h>
 #import <PushKit/PushKit.h>
 #import <CallKit/CallKit.h>
+#import "FirebasePluginMessageReceiver.h"
+
+@class CordovaCall;
+
+@interface CustomFCMReceiver : FirebasePluginMessageReceiver
+@property (nonatomic, weak) CordovaCall *cordovaCall;
+- (bool) sendNotification:(NSDictionary *)userInfo;
+@end
 
 @interface CordovaCall : CDVPlugin <PKPushRegistryDelegate, CXProviderDelegate>
 

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -33,6 +33,8 @@ NSString* const PENDING_RESPONSE_REJECT = @"pendingResponseReject";
 
 NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 
+static CustomFCMReceiver* customFCMReceiver;
+
 - (void)pluginInitialize
 {
     CXProviderConfiguration *providerConfiguration;
@@ -85,7 +87,9 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     self.VoIPPushToken = [[NSUserDefaults standardUserDefaults] stringForKey:KEY_VOIP_PUSH_TOKEN];
     webSockets = [[NSMutableDictionary alloc] init];
 
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleRemotePushNotification:) name:@"CallkitHandleRemotePushNotification" object:nil];
+    // Initialize a custom FCM message receiver
+    customFCMReceiver = [[CustomFCMReceiver alloc] init];
+    customFCMReceiver.cordovaCall = self;
 }
 
 // CallKit - Interface
@@ -874,16 +878,23 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     }
 }
 
-// Handles all remote push notifications sent from forked FCM, only action on a dismiss notification
-- (void)handleRemotePushNotification:(NSNotification *)notification {
-    NSDictionary *userInfo = notification.object;
-    [self logMessage:[NSString stringWithFormat:@"Received remote notification: %@", userInfo]];
+- (void)logMessage:(NSString *)message
+{
+    NSLog(@"[CordovaCall]: %@", message);
+}
+@end
+
+@implementation CustomFCMReceiver
+
+- (bool) sendNotification:(NSDictionary *)userInfo {
+    bool isHandled = false;
+    [self.cordovaCall logMessage:[NSString stringWithFormat:@"Received remote notification: %@", userInfo]];
     
     // Checks if payload param is in notification
     NSString *payloadString = userInfo[@"payload"];
     if (![payloadString isKindOfClass:[NSString class]] || payloadString.length == 0) {
-        [self logMessage:@"No valid payload string found in notification"];
-        return;
+        [self.cordovaCall logMessage:@"No valid payload string found in notification"];
+        return isHandled;
     }
 
     NSData *payloadData = [payloadString dataUsingEncoding:NSUTF8StringEncoding];
@@ -892,21 +903,19 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     // Parse JSON payload
     NSDictionary *payloadDict = [NSJSONSerialization JSONObjectWithData:payloadData options:0 error:&error];
     if (error || ![payloadDict isKindOfClass:[NSDictionary class]]) {
-        [self logMessage:[NSString stringWithFormat:@"Error parsing payload JSON: %@", error]];
-        return;
+        [self.cordovaCall logMessage:[NSString stringWithFormat:@"Error parsing payload JSON: %@", error]];
+        return isHandled;
     }
 
     // Do something if dismiss key is present and true
     if (payloadDict[@"dismiss"] == nil || payloadDict[@"dismiss"] == false) {
-        [self logMessage:@"Dismiss key not found in payload or is false"];
-        return;
+        [self.cordovaCall logMessage:@"Dismiss key not found in payload or is false"];
+        return isHandled;
     } else {
-        [self _dismissRingingCall];
+        [self.cordovaCall _dismissRingingCall];
+        isHandled = true;
     }
+    return isHandled;
 }
 
-- (void)logMessage:(NSString *)message
-{
-    NSLog(@"[CordovaCall]: %@", message);
-}
 @end


### PR DESCRIPTION
Use the proper way of handling custom FCM messages on iOS instead of forking the firebasex plugin.

Done by instantiating a `CustomFCMReceiver` class that inherits from `FirebasePluginMessageReceiver` which registers itself into `FirebasePluginMessageReceiverManager` that goes through each custom message receiver and has it process the push notification.

The sample code they gave does not work well since it requires JS to do the init, which isn't running for push notifications when the app is in the background or not running. The JS doesn't execute yet when the native code runs to process the notification.
https://github.com/dpa99c/cordova-plugin-firebasex-test

Note, this method probably only works for iOS as we're receiving the dismiss FCM notification while the CordovaCall plugin is running from triggering ringing. For Android the FCM plugin itself is the one spinning up with everything else not being loaded, which will luckily be someone else's headache to deal with.