### PR TITLE
CordovaCall checkCallPermission()  Allow for passing both onSucess and onFailure callbacks

### DIFF
--- a/www/CordovaCall.js
+++ b/www/CordovaCall.js
@@ -95,8 +95,8 @@ exports.on = function (e, f) {
   exec(success, error, "CordovaCall", "registerEvent", [e]);
 };
 
-exports.checkCallPermission = function (error) {
-  exec(null, error, "CordovaCall", "checkCallPermission", []);
+exports.checkCallPermission = function (success, error) {
+  exec(success, error, "CordovaCall", "checkCallPermission", []);
 };
 
 exports.canUseFullScreenIntent = function (success, error) {


### PR DESCRIPTION
…mission