### PR TITLE
Add uses-permission declaration for android.permission.POST_PROMOTED_NOTIFICATIONS

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -23,6 +23,7 @@
             <uses-permission android:name="android.permission.MANAGE_OWN_CALLS"/>
             <uses-permission android:name="android.permission.READ_PHONE_NUMBERS"/> <!-- needed by TelecomManager.getPhoneAccount() -->
             <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
+            <uses-permission android:name="android.permission.POST_PROMOTED_NOTIFICATIONS"/> <!-- important for the CallStyle notifications created to be promotable -->
         </config-file>
 
         <config-file parent="/manifest/application" target="AndroidManifest.xml">


### PR DESCRIPTION
Adds the missing POST_PROMOTED_NOTIFICATIONS non-runtime permission, which is at least one reason why (on certain versions of Android that the resulting CallStyle notifications launched in this plugin were not eligible for promotion / classification as live update notifications:

https://developer.android.com/develop/ui/views/notifications/live-update

<img width="895" height="473" alt="Screenshot from 2025-11-11 13-24-33" src="https://github.com/user-attachments/assets/a326a086-ef00-4bfd-8dc9-0aca19f39d61" />


<img width="665" height="438" alt="Screenshot from 2025-11-11 13-22-25" src="https://github.com/user-attachments/assets/5a78a95a-8591-4bf8-97cd-2176dfa67d32" />
