### PR TITLE
MyConnectionService: add call to connection.setRinging()  in connection.onShowIncomingCallUI

### DIFF
--- a/src/android/MyConnectionService.java
+++ b/src/android/MyConnectionService.java
@@ -189,6 +189,7 @@ public class MyConnectionService extends ConnectionService {
             @Override
             public void onShowIncomingCallUi() { // Only for self managed connections
                 Log.d(TAG, "onShowIncomingCallUi() invoked, for call_uuid: " + callUUID);
+                this.setRinging();
                 this.callNotification = new CallNotification(payloadString, context);
                 this.callNotification.show();
             }


### PR DESCRIPTION
Discovered that were sort of missing this when reading this tutorial/article: https://medium.com/@filipe.torres112/xamarin-android-self-managed-connectionservice-api-fa548c6897b

Without this the state of the connection is 1 (Connection.STATE_NEW)