### PR TITLE
Delete Unused/Bad Intent Filter Entries (For Registration Of CallActionReceiver by MyConnectionService)

### DIFF
--- a/src/android/MyConnectionService.java
+++ b/src/android/MyConnectionService.java
@@ -37,8 +37,6 @@ public class MyConnectionService extends ConnectionService {
 
         this.callActionReceiver = new CallActionReceiver();
         IntentFilter intentFilter = new IntentFilter();
-        intentFilter.addAction("rocks.app.callbridge.CALL_ANSWER");
-        intentFilter.addAction("rocks.app.callbridge.CALL_DECLINE");
         this.registerReceiver(this.callActionReceiver, intentFilter, RECEIVER_NOT_EXPORTED);
     }
 


### PR DESCRIPTION
These are not needed, and wouldn't be good anyway since they are hardcoded to rocks.apps.callbridge.
With explicit intents (directly referencing the CallActionReceiver these are not needed)