### PR TITLE
Tie Call Notification to A Foreground Service (Branched off of ongoing call notification)

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -24,6 +24,11 @@
             <uses-permission android:name="android.permission.READ_PHONE_NUMBERS"/> <!-- needed by TelecomManager.getPhoneAccount() -->
             <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
             <uses-permission android:name="android.permission.POST_PROMOTED_NOTIFICATIONS"/> <!-- important for the CallStyle notifications created to be promotable -->
+        
+            <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+
+            <!-- Permission for the "phoneCall" foreground service type (Required for Android 14+) -->
+            <uses-permission android:name="android.permission.FOREGROUND_SERVICE_PHONE_CALL" />
         </config-file>
 
         <config-file parent="/manifest/application" target="AndroidManifest.xml">
@@ -37,7 +42,9 @@
             />
             <service android:name="com.dmarc.cordovacall.MyConnectionService"
                      android:permission="android.permission.BIND_TELECOM_CONNECTION_SERVICE"
-                     android:exported="true">
+                     android:exported="true"
+                     android:foregroundServiceType="phoneCall"
+            >
                 <intent-filter>
                     <action android:name="android.telecom.ConnectionService" />
                 </intent-filter>

--- a/src/android/CallActionReceiver.java
+++ b/src/android/CallActionReceiver.java
@@ -23,21 +23,11 @@ public class CallActionReceiver extends BroadcastReceiver {
                 conn.onReject();
             } else if (action.equals("answerCall")) {
                 conn.onAnswer();
-            } else if (action.equals("hangUpCall")) {
-                conn.onDisconnect();
             } else {
                 throw new RuntimeException("Invalid action: " + action);
             }
         } else {
             Log.d(TAG, "Exiting, connection no longer exists. pushMessagePayload: " + pushMessagePayload);
-            if (intent.hasExtra("notificationID")) {
-                // For safety ensure any associated notification is closed (avoids bad UX if the normal logic
-                // that closes the notification when the connection is disconnected fails/crashes/etc.)
-                int notificationID = intent.getIntExtra("notificationID", 0);
-                Log.e(TAG, "Closing orphaned notification, ID: " + notificationID);
-                NotificationManager nm = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-                nm.cancel(notificationID);
-            }
         }
     }
 }

--- a/src/android/CallNotification.java
+++ b/src/android/CallNotification.java
@@ -1,5 +1,6 @@
 package com.dmarc.cordovacall;
 
+import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
@@ -10,9 +11,6 @@ import android.graphics.BitmapFactory;
 import android.media.RingtoneManager;
 import android.net.Uri;
 import android.os.Build;
-import android.os.Handler;
-import android.telecom.Connection;
-import android.telecom.DisconnectCause;
 import android.util.Log;
 
 import androidx.core.app.NotificationCompat;
@@ -20,7 +18,6 @@ import androidx.core.app.Person;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.net.URI;
 import java.util.Random;
 
 
@@ -31,8 +28,6 @@ public class CallNotification {
     private Integer notificationID;
     private Context context;
     private NotificationManager notificationManager;
-    private Runnable timeoutRunnable;
-    private Handler timeoutHandler = new Handler();
 
     private static final String NOTIFICATION_CHANNEL_ID = "incoming_calls";
 
@@ -50,7 +45,7 @@ public class CallNotification {
         this.createNotificationChannel();
     }
 
-    public void show(Style style) {
+    public Notification build(Style style) {
         int timeout = 30000;
 
         // NOTE: "Notifications should only launch a BroadcastReceiver from notification actions"
@@ -175,31 +170,13 @@ public class CallNotification {
         }
 
         Log.d(TAG, "launching call notification via android NotificationManager notify()...");
-        notificationManager.notify(this.notificationID, builder.build());
+        Notification notification = builder.build();
 
-        if (this.timeoutRunnable != null) {
-            this.timeoutHandler.removeCallbacks(this.timeoutRunnable);
-        }
-
-        this.timeoutRunnable = new Runnable() {
-            @Override
-            public void run() {
-                Log.d(TAG, "call missed, closing connection and call notification,");
-                Connection conn = MyConnectionService.getConnectionByPayload(pushMessagePayload);
-                conn.setDisconnected(new DisconnectCause(DisconnectCause.MISSED));
-                close();
-            }
-        };
-
-        this.timeoutHandler.postDelayed(timeoutRunnable, timeout);
+        return notification;
     }
 
-    public void close() {
-        Log.d(TAG, "closing call notification");
-        this.notificationManager.cancel(this.notificationID);
-        if (this.timeoutRunnable != null) {
-            this.timeoutHandler.removeCallbacks(this.timeoutRunnable);
-        }
+    public int getNotificationID() {
+        return this.notificationID;
     }
 
     private Uri getRingtoneURI() {

--- a/src/android/MyConnectionService.java
+++ b/src/android/MyConnectionService.java
@@ -1,14 +1,18 @@
 package com.dmarc.cordovacall;
 
+import static android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_PHONE_CALL;
+
 import org.apache.cordova.PluginResult;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import android.app.Notification;
 import android.content.Intent;
 import android.content.Context;
 import android.content.IntentFilter;
 import android.content.pm.PackageManager;
 import android.graphics.drawable.Icon;
+import android.os.Build;
 import android.os.Bundle;
 import android.telecom.Connection;
 import android.telecom.ConnectionRequest;
@@ -202,13 +206,14 @@ public class MyConnectionService extends ConnectionService {
                 Log.d(TAG, "onShowIncomingCallUi() invoked, for call_uuid: " + callUUID);
                 this.setRinging();
                 this.callNotification = new CallNotification(payloadString, context);
-                this.callNotification.show(CallNotification.Style.INCOMING_CALL);
-            }
+                Notification notification = this.callNotification.build(CallNotification.Style.INCOMING_CALL);
+                int notificationID = this.callNotification.getNotificationID();
 
-            private void closeNotification() {
-                if (this.callNotification != null) {
-                    this.callNotification.close();
-                    this.callNotification = null;
+                Log.d(TAG, "calling startForeground() for notification ID: " + notificationID);
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    startForeground(notificationID, notification, FOREGROUND_SERVICE_TYPE_PHONE_CALL);
+                } else {
+                    Log.e(TAG, "Unable to startForeground due to API level"); // TODO implement something
                 }
             }
 
@@ -219,7 +224,6 @@ public class MyConnectionService extends ConnectionService {
                 activeConnectionUUID = callUUID;
 
                 showWebApp("answerCall", payloadString);
-
                 CordovaCall.emitEvent("answer", new PluginResult(PluginResult.Status.OK, payloadString));
             }
 
@@ -253,10 +257,16 @@ public class MyConnectionService extends ConnectionService {
 
                 switch (state) {
                     case Connection.STATE_ACTIVE:
-                        this.callNotification.show(CallNotification.Style.ONGOING_CALL);
+                        Notification notification = this.callNotification.build(CallNotification.Style.ONGOING_CALL);
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                            // Call startForeground again which allows for updating the associated notification
+                            startForeground(this.callNotification.getNotificationID(), notification, FOREGROUND_SERVICE_TYPE_PHONE_CALL);
+                        } else {
+                            Log.e(TAG, "Unable to startForeground() due to API Level"); // TODO implement something or raise min level
+                        }
                         break;
                     case Connection.STATE_DISCONNECTED:
-                        this.closeNotification();
+                        stopForeground(STOP_FOREGROUND_REMOVE); // Cancels the associated notification
                         connectionMap.remove(callUUID);
                         if (activeConnectionUUID != null && activeConnectionUUID.equals(callUUID)) {
                             activeConnectionUUID = null;


### PR DESCRIPTION
**Must be acompannied by the below change to call startForegroundService (over in cordova-plugin-firebasex)**:
<img width="849" height="483" alt="Screenshot from 2025-11-18 12-04-01" src="https://github.com/user-attachments/assets/bc4e1d64-efa9-488a-9a22-111b98d1da0b" />


This an experiment to see if this would influence how the notifications are shown, by allowing the system to show the notification by using this.startForeground(... notification params ...) in MyConnectionService.

Uses a foreground service of type "FOREGROUND_SERVICE_TYPE_PHONE_CALL"


This promotes the MyConnectionService to a foreground service which will launch the incoming call notification:


<img width="613" height="219" alt="Screenshot from 2025-11-18 12-07-14" src="https://github.com/user-attachments/assets/1ba8ef2e-9069-4cc3-88cf-06c6795fb117" />


then transitions/updates the notification to an ongoing call notification

<img width="768" height="86" alt="Screenshot from 2025-11-18 12-07-31" src="https://github.com/user-attachments/assets/5e9aa56e-7b7f-4401-8162-7d75f799ad70" />


then returns the service to the background cancelling the notification:

<img width="768" height="86" alt="Screenshot from 2025-11-18 12-07-48" src="https://github.com/user-attachments/assets/121c9d28-63ec-4074-8970-cc9fe0e3d2a4" />


