### PR TITLE
Fix Logic That Should Finish IncomingCallActivity, When Corresponding Connection is Disconnected

### DIFF
--- a/src/android/IncomingCallActivity.java
+++ b/src/android/IncomingCallActivity.java
@@ -22,6 +22,8 @@ import android.widget.RelativeLayout;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -69,11 +71,9 @@ public class IncomingCallActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
 
         IntentFilter filter = new IntentFilter("connection_state_changed");
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            this.registerReceiver(this.callStateReceiver, filter, RECEIVER_NOT_EXPORTED);
-        } else {
-            this.registerReceiver(this.callStateReceiver, filter);
-        }
+
+        Log.d(TAG, "Registering callStateReciever");
+        LocalBroadcastManager.getInstance(this.getApplicationContext()).registerReceiver(callStateReceiver, filter);
 
         Connection connection = MyConnectionService.getConnectionByPayload(this.getPushMessagePayload());
         if (connection == null) {
@@ -183,6 +183,7 @@ public class IncomingCallActivity extends AppCompatActivity {
 
     protected void onDestroy() {
         super.onDestroy();
+        Log.d(TAG, "unregistering callStateReceiver");
         this.unregisterReceiver(this.callStateReceiver);
     }
 

--- a/src/android/MyConnectionService.java
+++ b/src/android/MyConnectionService.java
@@ -29,6 +29,7 @@ import androidx.annotation.NonNull;
 import androidx.core.app.NotificationCompat;
 import androidx.lifecycle.DefaultLifecycleObserver;
 import androidx.lifecycle.LifecycleOwner;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -299,10 +300,11 @@ public class MyConnectionService extends ConnectionService {
                         break;
                 }
 
+                Log.d(TAG, "broadcasting connection_state_changed call_uuid: " + callUUID + " state: " + state);
                 Intent intent = new Intent("connection_state_changed");
                 intent.putExtra("call_uuid", callUUID);
                 intent.putExtra("state", state);
-                context.sendBroadcast(intent);
+                LocalBroadcastManager.getInstance(context).sendBroadcast(intent);
             }
         };
 


### PR DESCRIPTION
Current broadcast / receiver logic does not work here, have switched it to use local broadcast manager, which is recommended over using global broadcasts.

It's now working.

This fixes an issue which was resulting in the IncomingCallActivity remaining open when the caller cancels the call.