### PR TITLE
IncomingCallActivity: Fix unregistering LocalBroadcastManager

### DIFF
--- a/src/android/IncomingCallActivity.java
+++ b/src/android/IncomingCallActivity.java
@@ -184,7 +184,7 @@ public class IncomingCallActivity extends AppCompatActivity {
     protected void onDestroy() {
         super.onDestroy();
         Log.d(TAG, "unregistering callStateReceiver");
-        this.unregisterReceiver(this.callStateReceiver);
+        LocalBroadcastManager.getInstance(this.getApplicationContext()).unregisterReceiver(callStateReceiver);
     }
 
     @Override


### PR DESCRIPTION
Sorry just realized this wasn't commited, its causing the app to crash on destroying the IncomingCallActivity