### PR TITLE
MyConnectionService: getConnection() fix

### DIFF
--- a/src/android/MyConnectionService.java
+++ b/src/android/MyConnectionService.java
@@ -171,7 +171,7 @@ public class MyConnectionService extends ConnectionService {
     }
 
     public static Connection getConnection() {
-        return connectionMap.get(activeConnectionUUID);
+        return activeConnectionUUID != null ? connectionMap.get(activeConnectionUUID) : null;
     }
 
     public static void endActiveCall() {


### PR DESCRIPTION
If activeConnectionUUID is null, and passed to ConncurrentHashMap.get( ) it errors out:

<img width="1043" height="220" alt="Screenshot from 2025-12-01 17-34-13" src="https://github.com/user-attachments/assets/a9c19af8-b34f-49e7-b044-c85f718c8050" />
