### PR TITLE
www/CordovaCall: add callUUID to endCall API

### DIFF
--- a/www/CordovaCall.js
+++ b/www/CordovaCall.js
@@ -62,8 +62,8 @@ exports.connectCall = function (success, error) {
   exec(success, error, "CordovaCall", "connectCall", []);
 };
 
-exports.endCall = function (success, error) {
-  exec(success, error, "CordovaCall", "endCall", []);
+exports.endCall = function (callUUID, success, error) {
+  exec(success, error, "CordovaCall", "endCall", [callUUID]);
 };
 
 exports.mute = function (success, error) {


### PR DESCRIPTION
NOTE:

The callUUID will be used in a later PR to correlate the endCall with the connection/call its associated with.

For now just updated the API so the facetalk PR is mergable without breaking things