### PR TITLE
Avoid Calling checkCallPermission() onResume (With the exception of being midst a sendCall action)

### DIFF
--- a/src/android/CordovaCall.java
+++ b/src/android/CordovaCall.java
@@ -169,7 +169,7 @@ public class CordovaCall extends CordovaPlugin {
     @Override
     public void onResume(boolean multitasking) {
         super.onResume(multitasking);
-        if (this.pendingAction != null && this.pendingAction.equals("sendCall")) {
+        if ("sendCall".equals(this.pendingAction)) {
             this.checkCallPermission();
         }
         setMainActivityInForegound(true);

--- a/src/android/CordovaCall.java
+++ b/src/android/CordovaCall.java
@@ -169,6 +169,9 @@ public class CordovaCall extends CordovaPlugin {
     @Override
     public void onResume(boolean multitasking) {
         super.onResume(multitasking);
+        if (this.pendingAction != null && this.pendingAction.equals("sendCall")) {
+            this.checkCallPermission();
+        }
         setMainActivityInForegound(true);
     }
 

--- a/src/android/CordovaCall.java
+++ b/src/android/CordovaCall.java
@@ -169,7 +169,7 @@ public class CordovaCall extends CordovaPlugin {
     @Override
     public void onResume(boolean multitasking) {
         super.onResume(multitasking);
-        if ("sendCall".equals(this.pendingAction)) {
+        if (this.pendingAction != null) {
             this.checkCallPermission();
         }
         setMainActivityInForegound(true);
@@ -199,6 +199,7 @@ public class CordovaCall extends CordovaPlugin {
                 pendingAction = "receiveCall";
                 this.checkCallPermission();
             }
+            pendingAction = null;
             return true;
         } else if (action.equals("sendCall")) {
             Connection conn = MyConnectionService.getConnection();
@@ -221,6 +222,7 @@ public class CordovaCall extends CordovaPlugin {
                     }
                 });*/
             }
+            pendingAction = null;
             return true;
         } else if (action.equals("connectCall")) {
             Connection conn = MyConnectionService.getConnection();

--- a/src/android/CordovaCall.java
+++ b/src/android/CordovaCall.java
@@ -169,7 +169,6 @@ public class CordovaCall extends CordovaPlugin {
     @Override
     public void onResume(boolean multitasking) {
         super.onResume(multitasking);
-        this.checkCallPermission();
         setMainActivityInForegound(true);
     }
 

--- a/src/android/CordovaCall.java
+++ b/src/android/CordovaCall.java
@@ -199,7 +199,6 @@ public class CordovaCall extends CordovaPlugin {
                 pendingAction = "receiveCall";
                 this.checkCallPermission();
             }
-            pendingAction = null;
             return true;
         } else if (action.equals("sendCall")) {
             Connection conn = MyConnectionService.getConnection();
@@ -222,7 +221,6 @@ public class CordovaCall extends CordovaPlugin {
                     }
                 });*/
             }
-            pendingAction = null;
             return true;
         } else if (action.equals("connectCall")) {
             Connection conn = MyConnectionService.getConnection();


### PR DESCRIPTION
<img width="1003" height="225" alt="Screenshot from 2025-12-09 12-06-36" src="https://github.com/user-attachments/assets/c4abd2f1-cb27-415a-9ac4-0431966f6165" />


TESTING NOTES:

This would possibly prevent in-advertently asking non-softphone users about phone account usage, in the event that the user returns to the app.
