### PR TITLE
Outgoing call foreground service fixes

### DIFF
--- a/src/android/MyConnectionService.java
+++ b/src/android/MyConnectionService.java
@@ -425,7 +425,7 @@ public class MyConnectionService extends ConnectionService {
                 .setOngoing(true)
                 .build();
 
-        startForeground(OUTGOING_CALL_NOTIFICATION_ID, notification);
+        startForeground(OUTGOING_CALL_NOTIFICATION_ID, notification, FOREGROUND_SERVICE_TYPE_PHONE_CALL);
 
         AudioManager audioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
         audioManager.setMode(AudioManager.MODE_IN_COMMUNICATION);

--- a/src/android/MyConnectionService.java
+++ b/src/android/MyConnectionService.java
@@ -420,6 +420,7 @@ public class MyConnectionService extends ConnectionService {
         Notification notification = new NotificationCompat.Builder(this, OUTGOING_CALL_NOTIFICATION_CHANNEL_ID)
                 .setContentTitle("Outgoing Call")
                 .setContentText("Active call")
+                .setSmallIcon(android.R.drawable.ic_menu_call)
                 .setPriority(NotificationCompat.PRIORITY_LOW)
                 .setOngoing(true)
                 .build();


### PR DESCRIPTION
Apparently the icon is critical to the notification associated with the foreground service:
<img width="1335" height="276" alt="image" src="https://github.com/user-attachments/assets/967886f4-d75f-4c6b-988b-6b24ceee3a0f" />

Also I think the 3rd arg to startForeground is supposed to be provided