### PR TITLE
Set Audio Mode For Incoming Calls

### DIFF
--- a/src/android/MyConnectionService.java
+++ b/src/android/MyConnectionService.java
@@ -268,6 +268,9 @@ public class MyConnectionService extends ConnectionService {
                 this.setActive();
                 activeConnectionUUID = callUUID;
 
+                AudioManager audioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
+                audioManager.setMode(AudioManager.MODE_IN_COMMUNICATION);
+
                 showWebApp("answerCall", payloadString);
                 CordovaCall.emitEvent("answer", new PluginResult(PluginResult.Status.OK, payloadString));
             }
@@ -314,6 +317,9 @@ public class MyConnectionService extends ConnectionService {
                             CordovaCall.unregisterMainActivityStateChangeListener(this.mainActivityChangeListener);
                         }
                         this.destroy();
+
+                        AudioManager audioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
+                        audioManager.setMode(AudioManager.MODE_NORMAL);
                         break;
                 }
 
@@ -395,6 +401,9 @@ public class MyConnectionService extends ConnectionService {
                     activeOutgoingConnection = null;
                     activeConnectionUUID = null;
                     stopForeground(true); // Return ConnectionService to background and cancels notification
+
+                    AudioManager audioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
+                    audioManager.setMode(AudioManager.MODE_NORMAL);
                 }
             }
         };


### PR DESCRIPTION
What this fixes:
- NOTHING really, but we probably should return to MODE_NORMAL when the outgoing call disconnects, and when the incoming call disconnects
- Using MODE_IN_COMMUNICATION for an incoming connection becoming active is probably correct, but this alone has not fixed the outstanding issue(s) with incoming calls getting a silenced microphone stream when entering the background.

Note:  AI recommends MODE_IN_COMMUNICATION be set prior to the WebRTC getUserMedia call.

Note: as of the previous PR everything is good with outgoing connections, so am now focusing on what is happening with incoming connections.