### PR TITLE
Fix for Incoming Calls Losing Microphone Access Shortly After App is Backgrounded

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -44,7 +44,6 @@
             <service android:name="com.dmarc.cordovacall.MyConnectionService"
                      android:permission="android.permission.BIND_TELECOM_CONNECTION_SERVICE"
                      android:exported="true"
-                     android:foregroundServiceType="phoneCall"
             >
                 <intent-filter>
                     <action android:name="android.telecom.ConnectionService" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -44,12 +44,19 @@
             <service android:name="com.dmarc.cordovacall.MyConnectionService"
                      android:permission="android.permission.BIND_TELECOM_CONNECTION_SERVICE"
                      android:exported="true"
-                     android:foregroundServiceType="phoneCall|microphone"
+                     android:foregroundServiceType="phoneCall"
             >
                 <intent-filter>
                     <action android:name="android.telecom.ConnectionService" />
                 </intent-filter>
             </service>
+            <service
+                android:name="com.dmarc.cordovacall.CallAudioService"
+                android:enabled="true"
+                android:foregroundServiceType="phoneCall|microphone"
+                android:exported="false"
+            />
+
             <receiver android:name="com.dmarc.cordovacall.CallActionReceiver" />
         </config-file>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -65,6 +65,7 @@
         <source-file src="src/android/CordovaCall.java" target-dir="src/com/dmarc/cordovacall" />
         <source-file src="src/android/IncomingCallActivity.java" target-dir="src/com/dmarc/cordovacall" />
         <source-file src="src/android/MyConnectionService.java" target-dir="src/com/dmarc/cordovacall" />
+        <source-file src="src/android/CallAudioService.java" target-dir="src/com/dmarc/cordovacall" />
         <source-file src="src/android/PhoneAccountManager.java" target-dir="src/com/dmarc/cordovacall" />
   </platform>
 

--- a/src/android/CallActionReceiver.java
+++ b/src/android/CallActionReceiver.java
@@ -14,6 +14,15 @@ public class CallActionReceiver extends BroadcastReceiver {
     public void onReceive(Context context, Intent intent) {
         String action = intent.getAction();
         Log.d(TAG, "onReceive, intent action: " + action);
+
+        if (action.equals("hangUpCall")) {
+            Connection activeConnection = MyConnectionService.getConnection();
+            if (activeConnection != null) {
+                activeConnection.onDisconnect();
+            }
+            return;
+        }
+
         String pushMessagePayload = intent.getStringExtra("pushMessagePayload");
 
         Connection conn = MyConnectionService.getConnectionByPayload(pushMessagePayload);

--- a/src/android/CallAudioService.java
+++ b/src/android/CallAudioService.java
@@ -21,34 +21,29 @@ import androidx.core.app.ServiceCompat;
  */
 public class CallAudioService extends Service {
     private static final String TAG = "CallAudioService";
-    private static final String CHANNEL_ID = "voip_call_channel";
-    private static final int NOTIFICATION_ID = 123;
 
     // onStartCommand is called in response to the startService() intent
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
         Log.d(TAG, "onStartCommand");
 
-        createNotificationChannel();
-        Notification notification = new NotificationCompat.Builder(this, CHANNEL_ID)
-                .setContentTitle("Active Call")
-                .setContentText("Microphone is in use")
-                .setSmallIcon(android.R.drawable.ic_menu_call)
-                .setOngoing(true)
-                .build();
+        String payload = intent.getStringExtra("payload");
+        CallNotification onGoingCallNotification = new CallNotification(payload, this.getApplicationContext());
+        Notification notification = onGoingCallNotification.build(CallNotification.Style.ONGOING_CALL);
+        int notificationID = onGoingCallNotification.getNotificationID();
 
         // For Android 14 (API 34) and above, you MUST specify types in code
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
             Log.d(TAG, "calling startForeground (service types phone call + microphone)...");
             ServiceCompat.startForeground(
                     this,
-                    NOTIFICATION_ID,
+                    notificationID,
                     notification,
                     ServiceInfo.FOREGROUND_SERVICE_TYPE_PHONE_CALL |
                             ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
             );
         } else {
-            startForeground(NOTIFICATION_ID, notification);
+            startForeground(notificationID, notification);
         }
 
         Log.d(TAG, "Setting audio mode to MODE_IN_COMMUNICATION");
@@ -56,18 +51,6 @@ public class CallAudioService extends Service {
         audioManager.setMode(AudioManager.MODE_IN_COMMUNICATION);
 
         return START_STICKY;
-    }
-
-    private void createNotificationChannel() {
-        NotificationChannel serviceChannel = new NotificationChannel(
-                CHANNEL_ID,
-                "VoIP Call Service",
-                NotificationManager.IMPORTANCE_LOW
-        );
-        NotificationManager manager = getSystemService(NotificationManager.class);
-        if (manager != null) {
-            manager.createNotificationChannel(serviceChannel);
-        }
     }
 
     // Note: Although a started service is stopped by a call to either stopSelf() or stopService(),

--- a/src/android/CallAudioService.java
+++ b/src/android/CallAudioService.java
@@ -1,0 +1,86 @@
+package com.dmarc.cordovacall;
+
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.Service;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.ServiceInfo;
+import android.media.AudioManager;
+import android.os.Build;
+import android.os.IBinder;
+import android.util.Log;
+
+import androidx.core.app.NotificationCompat;
+import androidx.core.app.ServiceCompat;
+
+public class CallAudioService extends Service {
+    private static final String TAG = "CallAudioService";
+    private static final String CHANNEL_ID = "voip_call_channel";
+    private static final int NOTIFICATION_ID = 123;
+
+    // onStartCommand is called in response to the startService() intent
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        Log.d(TAG, "onStartCommand");
+
+        createNotificationChannel();
+        Notification notification = new NotificationCompat.Builder(this, CHANNEL_ID)
+                .setContentTitle("Active Call")
+                .setContentText("Microphone is in use")
+                .setSmallIcon(android.R.drawable.ic_menu_call)
+                .setOngoing(true)
+                .build();
+
+        // For Android 14 (API 34) and above, you MUST specify types in code
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            Log.d(TAG, "calling startForeground (service types phone call + microphone)...");
+            ServiceCompat.startForeground(
+                    this,
+                    NOTIFICATION_ID,
+                    notification,
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_PHONE_CALL |
+                            ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+            );
+        } else {
+            startForeground(NOTIFICATION_ID, notification);
+        }
+
+        Log.d(TAG, "Setting audio mode to MODE_IN_COMMUNICATION");
+        AudioManager audioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
+        audioManager.setMode(AudioManager.MODE_IN_COMMUNICATION);
+
+        return START_STICKY;
+    }
+
+    private void createNotificationChannel() {
+        NotificationChannel serviceChannel = new NotificationChannel(
+                CHANNEL_ID,
+                "VoIP Call Service",
+                NotificationManager.IMPORTANCE_LOW
+        );
+        NotificationManager manager = getSystemService(NotificationManager.class);
+        if (manager != null) {
+            manager.createNotificationChannel(serviceChannel);
+        }
+    }
+
+    // Note: Although a started service is stopped by a call to either stopSelf() or stopService(),
+    // there isn't a respective callback for the service (there's no onStop() callback).
+    // Unless the service is bound to a client, the system destroys it when the service is stopped —onDestroy() is the only callback received.
+    @Override
+    public void onDestroy() {
+        Log.d(TAG, "onDestroy()");
+
+        Log.d(TAG, "Returning audio mode to MODE_NORMAL");
+        AudioManager audioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
+        audioManager.setMode(AudioManager.MODE_NORMAL);
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        // We don't provide binding, so return null
+        return null;
+    }
+}

--- a/src/android/CallAudioService.java
+++ b/src/android/CallAudioService.java
@@ -15,6 +15,10 @@ import android.util.Log;
 import androidx.core.app.NotificationCompat;
 import androidx.core.app.ServiceCompat;
 
+/**
+ * This is a service designed to be launched directly into the foreground throughout the duration
+ * of an active incoming or outgoing call to retain microphone access and set the correct audio mode.
+ */
 public class CallAudioService extends Service {
     private static final String TAG = "CallAudioService";
     private static final String CHANNEL_ID = "voip_call_channel";

--- a/src/android/CallAudioService.java
+++ b/src/android/CallAudioService.java
@@ -27,9 +27,13 @@ public class CallAudioService extends Service {
     public int onStartCommand(Intent intent, int flags, int startId) {
         Log.d(TAG, "onStartCommand");
 
-        String payload = intent.getStringExtra("payload");
+        String payload = intent.getStringExtra("pushMessagePayload");
         CallNotification onGoingCallNotification = new CallNotification(payload, this.getApplicationContext());
-        Notification notification = onGoingCallNotification.build(CallNotification.Style.ONGOING_CALL);
+        String calleeName = intent.getStringExtra("calleeName");
+        if (calleeName != null) {
+            onGoingCallNotification.setCalleeName(calleeName);
+        }
+        Notification notification = onGoingCallNotification.build(CallNotification.Style.ONGOING_CALL, NotificationCompat.PRIORITY_MIN);
         int notificationID = onGoingCallNotification.getNotificationID();
 
         // For Android 14 (API 34) and above, you MUST specify types in code

--- a/src/android/CallNotification.java
+++ b/src/android/CallNotification.java
@@ -46,7 +46,7 @@ public class CallNotification {
         this.createNotificationChannel();
     }
 
-    // Display name of the callee your calling (for outgoing calls)
+    // Display name of the callee you're calling (for outgoing calls)
     public void setCalleeName(String calleeName) {
         this.calleeName = calleeName;
     }

--- a/src/android/CallNotification.java
+++ b/src/android/CallNotification.java
@@ -25,6 +25,7 @@ public class CallNotification {
     private static final String TAG = "CallNotification";
 
     private String pushMessagePayload;
+    private String calleeName;
     private Integer notificationID;
     private Context context;
     private NotificationManager notificationManager;
@@ -43,6 +44,11 @@ public class CallNotification {
         this.notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
 
         this.createNotificationChannel();
+    }
+
+    // Display name of the callee your calling (for outgoing calls)
+    public void setCalleeName(String calleeName) {
+        this.calleeName = calleeName;
     }
 
     public Notification build(Style style) {
@@ -82,13 +88,13 @@ public class CallNotification {
         );
 
         JSONObject payload = null;
-        try {
-            payload = new JSONObject(this.pushMessagePayload);
-        } catch (JSONException e) {
-            throw new RuntimeException("CallNotification unable to parse pushMessagePayload, error: " + e);
+        if (this.pushMessagePayload != null) {
+            try {
+                payload = new JSONObject(this.pushMessagePayload);
+            } catch (JSONException e) {
+                throw new RuntimeException("CallNotification unable to parse pushMessagePayload, error: " + e);
+            }
         }
-
-        String callerName = payload.optString("from", "UNKNOWN");
 
         String contentTitle;
         switch (style) {
@@ -102,6 +108,8 @@ public class CallNotification {
                 throw new RuntimeException("No CallNotification contentTitle defined for style: " + style);
         }
 
+        String peerName = payload != null ? payload.optString("from", "UNKNOWN") : this.calleeName;
+
         NotificationCompat.Builder builder = new NotificationCompat.Builder(this.context, CallNotification.NOTIFICATION_CHANNEL_ID)
                 .setContentTitle(contentTitle)
                 .setSmallIcon(android.R.drawable.ic_menu_call)
@@ -112,9 +120,9 @@ public class CallNotification {
                 .setOngoing(true); // Can't be "dismissed" by the user, app will handle closing it
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-            Log.d(TAG, "Creating CallStyle.forIncomingCall style notification (as this is supported by the device)...");
+            Log.d(TAG, "Creating call-style notification (as this is supported by the device)...");
             Person callerPerson = new Person.Builder()
-                    .setName(callerName)
+                    .setName(peerName)
                     .setImportant(true)
                     .build();
 
@@ -135,7 +143,7 @@ public class CallNotification {
                 builder.setStyle(NotificationCompat.CallStyle.forOngoingCall(callerPerson, hangupPendingIntent));
             }
         } else {
-            builder.setContentText(callerName);
+            builder.setContentText(peerName);
 
             if (style == Style.INCOMING_CALL) {
                 builder.addAction(android.R.drawable.ic_menu_call, "Answer", answerPendingIntent)

--- a/src/android/MyConnectionService.java
+++ b/src/android/MyConnectionService.java
@@ -237,6 +237,9 @@ public class MyConnectionService extends ConnectionService {
             }
 
             public void cancelIncomingCallNotification() {
+                if (this.incomingCallNotification == null) {
+                    return;
+                }
                 NotificationManager notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
                 notificationManager.cancel(this.incomingCallNotification.getNotificationID());
             }

--- a/src/android/MyConnectionService.java
+++ b/src/android/MyConnectionService.java
@@ -96,7 +96,7 @@ public class MyConnectionService extends ConnectionService {
                 } else {
                     if (conn.getState() == Connection.STATE_DISCONNECTED) {
                         Log.d(TAG, "Call is already marked disconnected, call_uuid: " + callUUID);
-                    } else {
+                    } else if (conn.getState() == Connection.STATE_RINGING) {
                         Log.d(TAG, "Calling connection.onAbort() in response to pushMessagePayload.dismiss, call_uuid: " + callUUID);
                         conn.onAbort();
                     }
@@ -254,6 +254,7 @@ public class MyConnectionService extends ConnectionService {
 
                 Log.d(TAG, "Starting CallAudioService...");
                 Intent intent = new Intent(getApplicationContext(), CallAudioService.class);
+                intent.putExtra("pushMessagePayload", payloadString);
                 startForegroundService(intent);
 
                 Log.d(TAG, "Emitting CordovaCall answer event...");
@@ -402,6 +403,7 @@ public class MyConnectionService extends ConnectionService {
 
         Log.d(TAG, "Starting CallAudioService foreground service...");
         Intent intent = new Intent(getApplicationContext(), CallAudioService.class);
+        intent.putExtra("calleeName", request.getExtras().getString("to"));
         startForegroundService(intent);
 
         // Set capabilities to indicate this handles audio

--- a/src/android/MyConnectionService.java
+++ b/src/android/MyConnectionService.java
@@ -99,8 +99,6 @@ public class MyConnectionService extends ConnectionService {
                     } else if (conn.getState() == Connection.STATE_RINGING) {
                         Log.d(TAG, "Calling connection.onAbort() in response to pushMessagePayload.dismiss, call_uuid: " + callUUID);
                         conn.onAbort();
-                    } else {
-                        conn.onDisconnect();
                     }
                 }
             } else {

--- a/src/android/MyConnectionService.java
+++ b/src/android/MyConnectionService.java
@@ -252,19 +252,12 @@ public class MyConnectionService extends ConnectionService {
 
                 showWebApp("answerCall", payloadString);
 
-                // TODO: create action (similar to connectCall for facetalk to tell native layer to set call active, start mic service, etc.)
-                final Handler handler = new Handler();
-                handler.postDelayed(new Runnable() {
-                    @Override
-                    public void run() {
-                        Log.d(TAG, "Starting CallAudioService...");
-                        Intent intent = new Intent(getApplicationContext(), CallAudioService.class);
-                        startForegroundService(intent);
+                Log.d(TAG, "Starting CallAudioService...");
+                Intent intent = new Intent(getApplicationContext(), CallAudioService.class);
+                startForegroundService(intent);
 
-                        Log.d(TAG, "Emitting CordovaCall answer event...");
-                        CordovaCall.emitEvent("answer", new PluginResult(PluginResult.Status.OK, payloadString));
-                    }
-                }, 3000);
+                Log.d(TAG, "Emitting CordovaCall answer event...");
+                CordovaCall.emitEvent("answer", new PluginResult(PluginResult.Status.OK, payloadString));
             }
 
             @Override

--- a/src/android/MyConnectionService.java
+++ b/src/android/MyConnectionService.java
@@ -99,6 +99,8 @@ public class MyConnectionService extends ConnectionService {
                     } else if (conn.getState() == Connection.STATE_RINGING) {
                         Log.d(TAG, "Calling connection.onAbort() in response to pushMessagePayload.dismiss, call_uuid: " + callUUID);
                         conn.onAbort();
+                    } else {
+                        conn.onDisconnect();
                     }
                 }
             } else {

--- a/src/android/MyConnectionService.java
+++ b/src/android/MyConnectionService.java
@@ -233,7 +233,7 @@ public class MyConnectionService extends ConnectionService {
                     @Override
                     public void run() {
                         if (getState() == Connection.STATE_ACTIVE) {
-                            updateNotification();
+                            //updateNotification();
                         }
                     }
                 };
@@ -243,23 +243,8 @@ public class MyConnectionService extends ConnectionService {
                 this.callNotification = new CallNotification(payloadString, context);
                 Notification notification = this.callNotification.build(CallNotification.Style.INCOMING_CALL);
 
-                startForeground(this.callNotification.getNotificationID(), notification, FOREGROUND_SERVICE_TYPE_PHONE_CALL | FOREGROUND_SERVICE_TYPE_MICROPHONE);
-            }
-
-            private void updateNotification() {
-                CallNotification.Style style = this.getState() == Connection.STATE_RINGING ? CallNotification.Style.INCOMING_CALL : CallNotification.Style.ONGOING_CALL;
-
-                // Lowering the priority of the ongoing call notification (when the MainActivity is in the foreground)
-                // is done to prevent the notification from being displayed as a card that
-                // would overlap the top portion of the MainActivity.
-                boolean isInForeground = CordovaCall.isMainActivityInForeground();
-                int priority = (style == CallNotification.Style.ONGOING_CALL && isInForeground) ? NotificationCompat.PRIORITY_MIN : NotificationCompat.PRIORITY_HIGH;
-
-                Log.d(TAG, "updating notification style: " + style + " priority: " + priority);
-                Notification notification = this.callNotification.build(style, priority);
-
-                // Call startForeground again which allows for updating the associated notification of the same ID
-                startForeground(this.callNotification.getNotificationID(), notification, FOREGROUND_SERVICE_TYPE_PHONE_CALL | FOREGROUND_SERVICE_TYPE_MICROPHONE);
+                NotificationManager notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+                notificationManager.notify(this.callNotification.getNotificationID(), notification);
             }
 
             @Override
@@ -268,11 +253,22 @@ public class MyConnectionService extends ConnectionService {
                 this.setActive();
                 activeConnectionUUID = callUUID;
 
-                AudioManager audioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
-                audioManager.setMode(AudioManager.MODE_IN_COMMUNICATION);
-
                 showWebApp("answerCall", payloadString);
-                CordovaCall.emitEvent("answer", new PluginResult(PluginResult.Status.OK, payloadString));
+
+
+                // TODO: create action (similar to connectCall for facetalk to tell native layer to set call active, start mic service, etc.)
+                final Handler handler = new Handler();
+                handler.postDelayed(new Runnable() {
+                    @Override
+                    public void run() {
+                        Log.d(TAG, "Starting CallAudioService...");
+                        Intent intent = new Intent(getApplicationContext(), CallAudioService.class);
+                        startForegroundService(intent);
+
+                        Log.d(TAG, "Emitting CordovaCall answer event...");
+                        CordovaCall.emitEvent("answer", new PluginResult(PluginResult.Status.OK, payloadString));
+                    }
+                }, 3000);
             }
 
             @Override
@@ -283,12 +279,18 @@ public class MyConnectionService extends ConnectionService {
                 showWebApp("declineCall", payloadString); // Controversial UX but doing so that we can tell the web app to reject the call (which may let the caller not it was declined)
 
                 CordovaCall.emitEvent("reject", new PluginResult(PluginResult.Status.OK, payloadString));
+
+                NotificationManager notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+                notificationManager.cancel(this.callNotification.getNotificationID());
             }
 
             @Override
             public void onAbort() {
                 Log.d(TAG, "onAbort, call_uuid: " + callUUID);
                 this.setDisconnected(new DisconnectCause(DisconnectCause.CANCELED));
+
+                NotificationManager notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+                notificationManager.cancel(this.callNotification.getNotificationID());
             }
 
             @Override
@@ -305,10 +307,8 @@ public class MyConnectionService extends ConnectionService {
 
                 switch (state) {
                     case Connection.STATE_ACTIVE:
-                        updateNotification(); // Will update it to an "ongoing" CallStyle notification
                         break;
                     case Connection.STATE_DISCONNECTED:
-                        stopForeground(STOP_FOREGROUND_REMOVE); // Cancels the associated notification
                         connectionMap.remove(callUUID);
                         if (activeConnectionUUID != null && activeConnectionUUID.equals(callUUID)) {
                             activeConnectionUUID = null;
@@ -318,8 +318,9 @@ public class MyConnectionService extends ConnectionService {
                         }
                         this.destroy();
 
-                        AudioManager audioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
-                        audioManager.setMode(AudioManager.MODE_NORMAL);
+//                        Log.d(TAG, "Stopping CallAudioService...");
+//                        Intent serviceIntent = new Intent(context, CallAudioService.class);
+//                        context.stopService(serviceIntent);
                         break;
                 }
 
@@ -435,7 +436,7 @@ public class MyConnectionService extends ConnectionService {
                 .setOngoing(true)
                 .build();
 
-        startForeground(OUTGOING_CALL_NOTIFICATION_ID, notification, FOREGROUND_SERVICE_TYPE_PHONE_CALL | FOREGROUND_SERVICE_TYPE_MICROPHONE);
+        startForeground(OUTGOING_CALL_NOTIFICATION_ID, notification, FOREGROUND_SERVICE_TYPE_PHONE_CALL);
 
         AudioManager audioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
         audioManager.setMode(AudioManager.MODE_IN_COMMUNICATION);

--- a/src/android/MyConnectionService.java
+++ b/src/android/MyConnectionService.java
@@ -221,7 +221,7 @@ public class MyConnectionService extends ConnectionService {
         connectionAddedMap.remove(callUUID);
 
         final Connection connection = new Connection() {
-            CallNotification callNotification;
+            CallNotification incomingCallNotification;
             Runnable mainActivityChangeListener;
 
             @Override
@@ -229,32 +229,28 @@ public class MyConnectionService extends ConnectionService {
                 Log.d(TAG, "onShowIncomingCallUi() invoked, for call_uuid: " + callUUID);
                 this.setRinging();
 
-                this.mainActivityChangeListener = new Runnable() {
-                    @Override
-                    public void run() {
-                        if (getState() == Connection.STATE_ACTIVE) {
-                            //updateNotification();
-                        }
-                    }
-                };
-
-                CordovaCall.registerMainActivityStateChangeListener(this.mainActivityChangeListener);
-
-                this.callNotification = new CallNotification(payloadString, context);
-                Notification notification = this.callNotification.build(CallNotification.Style.INCOMING_CALL);
+                this.incomingCallNotification = new CallNotification(payloadString, context);
+                Notification notification = this.incomingCallNotification.build(CallNotification.Style.INCOMING_CALL);
 
                 NotificationManager notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
-                notificationManager.notify(this.callNotification.getNotificationID(), notification);
+                notificationManager.notify(this.incomingCallNotification.getNotificationID(), notification);
+            }
+
+            public void cancelIncomingCallNotification() {
+                NotificationManager notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+                notificationManager.cancel(this.incomingCallNotification.getNotificationID());
             }
 
             @Override
             public void onAnswer() {
                 Log.d(TAG, "onAnswer()");
+
+                cancelIncomingCallNotification();
+
                 this.setActive();
                 activeConnectionUUID = callUUID;
 
                 showWebApp("answerCall", payloadString);
-
 
                 // TODO: create action (similar to connectCall for facetalk to tell native layer to set call active, start mic service, etc.)
                 final Handler handler = new Handler();
@@ -279,18 +275,12 @@ public class MyConnectionService extends ConnectionService {
                 showWebApp("declineCall", payloadString); // Controversial UX but doing so that we can tell the web app to reject the call (which may let the caller not it was declined)
 
                 CordovaCall.emitEvent("reject", new PluginResult(PluginResult.Status.OK, payloadString));
-
-                NotificationManager notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
-                notificationManager.cancel(this.callNotification.getNotificationID());
             }
 
             @Override
             public void onAbort() {
                 Log.d(TAG, "onAbort, call_uuid: " + callUUID);
                 this.setDisconnected(new DisconnectCause(DisconnectCause.CANCELED));
-
-                NotificationManager notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
-                notificationManager.cancel(this.callNotification.getNotificationID());
             }
 
             @Override
@@ -318,9 +308,11 @@ public class MyConnectionService extends ConnectionService {
                         }
                         this.destroy();
 
-//                        Log.d(TAG, "Stopping CallAudioService...");
-//                        Intent serviceIntent = new Intent(context, CallAudioService.class);
-//                        context.stopService(serviceIntent);
+                        cancelIncomingCallNotification();
+
+                        Log.d(TAG, "Stopping CallAudioService...");
+                        Intent serviceIntent = new Intent(context, CallAudioService.class);
+                        context.stopService(serviceIntent);
                         break;
                 }
 
@@ -401,10 +393,10 @@ public class MyConnectionService extends ConnectionService {
                     this.destroy();
                     activeOutgoingConnection = null;
                     activeConnectionUUID = null;
-                    stopForeground(true); // Return ConnectionService to background and cancels notification
 
-                    AudioManager audioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
-                    audioManager.setMode(AudioManager.MODE_NORMAL);
+                    Log.d(TAG, "Stopping CallAudioService foreground service...");
+                    Intent serviceIntent = new Intent(context, CallAudioService.class);
+                    context.stopService(serviceIntent);
                 }
             }
         };
@@ -415,31 +407,9 @@ public class MyConnectionService extends ConnectionService {
             connection.setStatusHints(statusHints);
         }
 
-        final String OUTGOING_CALL_NOTIFICATION_CHANNEL_ID = "outgoing_calls";
-
-        NotificationChannel serviceChannel = new NotificationChannel(
-                OUTGOING_CALL_NOTIFICATION_CHANNEL_ID,
-                "Outgoing Calls",
-                NotificationManager.IMPORTANCE_LOW
-        );
-        NotificationManager manager = getSystemService(NotificationManager.class);
-        if (manager != null) {
-            manager.createNotificationChannel(serviceChannel);
-        }
-
-        final int OUTGOING_CALL_NOTIFICATION_ID = 1;
-        Notification notification = new NotificationCompat.Builder(this, OUTGOING_CALL_NOTIFICATION_CHANNEL_ID)
-                .setContentTitle("Outgoing Call")
-                .setContentText("Active call")
-                .setSmallIcon(android.R.drawable.ic_menu_call)
-                .setPriority(NotificationCompat.PRIORITY_LOW)
-                .setOngoing(true)
-                .build();
-
-        startForeground(OUTGOING_CALL_NOTIFICATION_ID, notification, FOREGROUND_SERVICE_TYPE_PHONE_CALL);
-
-        AudioManager audioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
-        audioManager.setMode(AudioManager.MODE_IN_COMMUNICATION);
+        Log.d(TAG, "Starting CallAudioService foreground service...");
+        Intent intent = new Intent(getApplicationContext(), CallAudioService.class);
+        startForegroundService(intent);
 
         // Set capabilities to indicate this handles audio
         connection.setConnectionCapabilities(


### PR DESCRIPTION
- Refrains from promoting the MyConnectionService to the background - instead the ConnectionService will remain running as a background service
- Introduces a new service (CallAudioService) separate from the connection service which will be started as a foreground service, this offers better seperation of concerns and makes it easier to understand the lifecyle of things (the connection service is designed as an "always" present and running background service, and the foreground service is mostly for indicating to the user that there is an ongoing call complete with the ongoing call notification, microphone in-use indicator etc.)- 
- Moves the audio mode logic over to CallAudioService (as entering/exiting MODE_IN_COMMUNICATION matches the lifecycle of that service)
- The problem with incoming calls quickly losing microphone access when in the background stemed from how we were launching the "microphone|phoneCall" foreground service, as A.I. predicted it was because we were launching this even before the connection was active (in connnection onShowIncomingCallUI) moving it to the later onAnswer has addressed this. 

Needs to be merged with: https://github.com/iotum/cordova-plugin-firebasex/pull/15/files
^ Another advantage of using a separate service as the foreground service is we can just simplify/assume the MyConnectionService will run as a background-only service