### PR TITLE
Split CallNotification.java Into 2 Separate Files + Correct On-going Call Notification Config

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -60,7 +60,8 @@
         </config-file>
 
         <source-file src="src/android/CallActionReceiver.java" target-dir="src/com/dmarc/cordovacall" />
-        <source-file src="src/android/CallNotification.java" target-dir="src/com/dmarc/cordovacall" />
+        <source-file src="src/android/IncomingCallNotification.java" target-dir="src/com/dmarc/cordovacall" />
+        <source-file src="src/android/OngoingCallNotification.java" target-dir="src/com/dmarc/cordovacall" />
         <source-file src="src/android/CordovaCall.java" target-dir="src/com/dmarc/cordovacall" />
         <source-file src="src/android/IncomingCallActivity.java" target-dir="src/com/dmarc/cordovacall" />
         <source-file src="src/android/MyConnectionService.java" target-dir="src/com/dmarc/cordovacall" />

--- a/src/android/CallActionReceiver.java
+++ b/src/android/CallActionReceiver.java
@@ -19,6 +19,11 @@ public class CallActionReceiver extends BroadcastReceiver {
             Connection activeConnection = MyConnectionService.getConnection();
             if (activeConnection != null) {
                 activeConnection.onDisconnect();
+            } else {
+                Log.d(TAG, "no active call to disconnect (possibly already disconnected), closing notification");
+                int notificationID = intent.getIntExtra("notificationID", 0);
+                NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+                notificationManager.cancel(notificationID);
             }
             return;
         }

--- a/src/android/CallAudioService.java
+++ b/src/android/CallAudioService.java
@@ -1,8 +1,6 @@
 package com.dmarc.cordovacall;
 
 import android.app.Notification;
-import android.app.NotificationChannel;
-import android.app.NotificationManager;
 import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
@@ -12,7 +10,6 @@ import android.os.Build;
 import android.os.IBinder;
 import android.util.Log;
 
-import androidx.core.app.NotificationCompat;
 import androidx.core.app.ServiceCompat;
 
 /**
@@ -27,13 +24,10 @@ public class CallAudioService extends Service {
     public int onStartCommand(Intent intent, int flags, int startId) {
         Log.d(TAG, "onStartCommand");
 
-        String payload = intent.getStringExtra("pushMessagePayload");
-        CallNotification onGoingCallNotification = new CallNotification(payload, this.getApplicationContext());
-        String calleeName = intent.getStringExtra("calleeName");
-        if (calleeName != null) {
-            onGoingCallNotification.setCalleeName(calleeName);
-        }
-        Notification notification = onGoingCallNotification.build(CallNotification.Style.ONGOING_CALL, NotificationCompat.PRIORITY_MIN);
+        String peerName = intent.getStringExtra("peerName");
+        OngoingCallNotification onGoingCallNotification = new OngoingCallNotification(this.getApplicationContext(), peerName);
+
+        Notification notification = onGoingCallNotification.build();
         int notificationID = onGoingCallNotification.getNotificationID();
 
         // For Android 14 (API 34) and above, you MUST specify types in code

--- a/src/android/CallAudioService.java
+++ b/src/android/CallAudioService.java
@@ -24,7 +24,10 @@ public class CallAudioService extends Service {
     public int onStartCommand(Intent intent, int flags, int startId) {
         Log.d(TAG, "onStartCommand");
 
-        String peerName = intent.getStringExtra("peerName");
+        String peerName = intent != null ? intent.getStringExtra("peerName") : null;
+        if (peerName == null) {
+            peerName = "Unknown";
+        }
         OngoingCallNotification onGoingCallNotification = new OngoingCallNotification(this.getApplicationContext(), peerName);
 
         Notification notification = onGoingCallNotification.build();

--- a/src/android/IncomingCallNotification.java
+++ b/src/android/IncomingCallNotification.java
@@ -6,7 +6,6 @@ import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
-import android.content.pm.PackageManager;
 import android.graphics.BitmapFactory;
 import android.media.RingtoneManager;
 import android.net.Uri;
@@ -21,41 +20,26 @@ import org.json.JSONObject;
 import java.util.Random;
 
 
-public class CallNotification {
-    private static final String TAG = "CallNotification";
+public class IncomingCallNotification {
+    private static final String TAG = "IncomingCallNotification";
 
     private String pushMessagePayload;
-    private String calleeName;
     private Integer notificationID;
     private Context context;
     private NotificationManager notificationManager;
 
     private static final String NOTIFICATION_CHANNEL_ID = "incoming_calls";
 
-    public enum Style {
-        INCOMING_CALL,
-        ONGOING_CALL
-    }
-
-    public CallNotification(String pushMessagePayload, Context context) {
+    public IncomingCallNotification(String pushMessagePayload, Context context) {
         this.pushMessagePayload = pushMessagePayload;
-        this.notificationID = new Random().nextInt(100000) + 1; // Random int > 0 TODO: maybe derive from call UUID string
+        this.notificationID = new Random().nextInt(100000) + 1;
         this.context = context;
         this.notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
 
         this.createNotificationChannel();
     }
 
-    // Display name of the callee you're calling (for outgoing calls)
-    public void setCalleeName(String calleeName) {
-        this.calleeName = calleeName;
-    }
-
-    public Notification build(Style style) {
-        return this.build(style, NotificationCompat.PRIORITY_HIGH);
-    }
-
-    public Notification build(Style style, int priority) {
+    public Notification build() {
         int timeout = 30000;
 
         // NOTE: "Notifications should only launch a BroadcastReceiver from notification actions"
@@ -78,43 +62,20 @@ public class CallNotification {
                 PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE
         );
 
-        Intent hangupIntent = new Intent(this.context, CallActionReceiver.class);
-        hangupIntent.setAction("hangUpCall");
-        hangupIntent.putExtra("pushMessagePayload", this.pushMessagePayload);
-        hangupIntent.putExtra("notificationID", this.notificationID);
-        PendingIntent hangupPendingIntent = PendingIntent.getBroadcast(
-                this.context, 0, hangupIntent,
-                PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE
-        );
-
         JSONObject payload = null;
-        if (this.pushMessagePayload != null) {
-            try {
-                payload = new JSONObject(this.pushMessagePayload);
-            } catch (JSONException e) {
-                throw new RuntimeException("CallNotification unable to parse pushMessagePayload, error: " + e);
-            }
+        try {
+            payload = new JSONObject(this.pushMessagePayload);
+        } catch (JSONException e) {
+            throw new RuntimeException("IncomingCallNotification: unable to parse pushMessagePayload, error: " + e);
         }
 
-        String contentTitle;
-        switch (style) {
-            case INCOMING_CALL:
-                contentTitle = "Incoming call";
-                break;
-            case ONGOING_CALL:
-                contentTitle = "Ongoing call";
-                break;
-            default:
-                throw new RuntimeException("No CallNotification contentTitle defined for style: " + style);
-        }
+        String peerName = payload.optString("from", "UNKNOWN");
 
-        String peerName = payload != null ? payload.optString("from", "UNKNOWN") : this.calleeName;
-
-        NotificationCompat.Builder builder = new NotificationCompat.Builder(this.context, CallNotification.NOTIFICATION_CHANNEL_ID)
-                .setContentTitle(contentTitle)
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(this.context, IncomingCallNotification.NOTIFICATION_CHANNEL_ID)
+                .setContentTitle("Incoming call")
                 .setSmallIcon(android.R.drawable.ic_menu_call)
                 .setLargeIcon(BitmapFactory.decodeResource(this.context.getResources(), android.R.drawable.sym_def_app_icon))
-                .setPriority(priority)
+                .setPriority(NotificationCompat.PRIORITY_HIGH)
                 .setCategory(NotificationCompat.CATEGORY_CALL)
                 .setSound(this.getRingtoneURI()) // For compatibility with Android 8.0 and less. (normally set through channel)
                 .setOngoing(true); // Can't be "dismissed" by the user, app will handle closing it
@@ -127,33 +88,24 @@ public class CallNotification {
                     .build();
 
             // "CallStyle notifications must be for a foreground service or user initated job or use a fullScreenIntent."
+            // NOTE: this requirements is met by the use of a full-screen intent
+            builder.setStyle(NotificationCompat.CallStyle.forIncomingCall(callerPerson, declinePendingIntent, answerPendingIntent));
 
-            if (style == style.INCOMING_CALL) {
-                builder.setStyle(NotificationCompat.CallStyle.forIncomingCall(callerPerson, declinePendingIntent, answerPendingIntent));
-
-                Intent fullScreenIntent = new Intent(this.context, IncomingCallActivity.class);
-                fullScreenIntent.putExtra("pushMessagePayload", this.pushMessagePayload);
-                fullScreenIntent.setFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
-                PendingIntent fullScreenPendingIntent = PendingIntent.getActivity(
-                        this.context, 0, fullScreenIntent,
-                        PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_CANCEL_CURRENT
-                );
-                builder.setFullScreenIntent(fullScreenPendingIntent, true);
-            } else if (style == style.ONGOING_CALL) {
-                builder.setStyle(NotificationCompat.CallStyle.forOngoingCall(callerPerson, hangupPendingIntent));
-            }
+            Intent fullScreenIntent = new Intent(this.context, IncomingCallActivity.class);
+            fullScreenIntent.putExtra("pushMessagePayload", this.pushMessagePayload);
+            fullScreenIntent.setFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+            PendingIntent fullScreenPendingIntent = PendingIntent.getActivity(
+                    this.context, 0, fullScreenIntent,
+                    PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_CANCEL_CURRENT
+            );
+            builder.setFullScreenIntent(fullScreenPendingIntent, true);
         } else {
+            Log.d(TAG, "Creating a normal (non call-style) incoming call notification (due to lack of support of call-style notifications)...");
             builder.setContentText(peerName);
-
-            if (style == Style.INCOMING_CALL) {
-                builder.addAction(android.R.drawable.ic_menu_call, "Answer", answerPendingIntent)
-                        .addAction(android.R.drawable.ic_menu_close_clear_cancel, "Decline", declinePendingIntent);
-            } else if (style == Style.ONGOING_CALL) {
-                builder.addAction(android.R.drawable.ic_menu_call, "Hang up", hangupPendingIntent);
-            }
+            builder.addAction(android.R.drawable.ic_menu_call, "Answer", answerPendingIntent)
+                    .addAction(android.R.drawable.ic_menu_close_clear_cancel, "Decline", declinePendingIntent);
         }
 
-        Log.d(TAG, "launching call notification via android NotificationManager notify()...");
         Notification notification = builder.build();
 
         return notification;
@@ -172,7 +124,7 @@ public class CallNotification {
     // The notification sound on > Android 8.0 comes from the notification channel.
     private void createNotificationChannel() {
         NotificationChannel channel = new NotificationChannel(
-                CallNotification.NOTIFICATION_CHANNEL_ID,
+                IncomingCallNotification.NOTIFICATION_CHANNEL_ID,
                 "Incoming Calls",
                 NotificationManager.IMPORTANCE_HIGH
         );

--- a/src/android/MyConnectionService.java
+++ b/src/android/MyConnectionService.java
@@ -409,7 +409,7 @@ public class MyConnectionService extends ConnectionService {
 
         Log.d(TAG, "Starting CallAudioService foreground service...");
         Intent intent = new Intent(getApplicationContext(), CallAudioService.class);
-        intent.putExtra("peerName", request.getExtras().getString("to"));
+        intent.putExtra("peerName", request.getExtras().getString("to", "uknown"));
         startForegroundService(intent);
 
         // Set capabilities to indicate this handles audio

--- a/src/android/MyConnectionService.java
+++ b/src/android/MyConnectionService.java
@@ -218,10 +218,12 @@ public class MyConnectionService extends ConnectionService {
         }
         final String callUUID = _callUUID;
 
+        String callerName = payload.optString("from", "UNKNOWN CALLER");
+
         connectionAddedMap.remove(callUUID);
 
         final Connection connection = new Connection() {
-            CallNotification incomingCallNotification;
+            IncomingCallNotification incomingCallNotification;
             Runnable mainActivityChangeListener;
 
             @Override
@@ -229,8 +231,8 @@ public class MyConnectionService extends ConnectionService {
                 Log.d(TAG, "onShowIncomingCallUi() invoked, for call_uuid: " + callUUID);
                 this.setRinging();
 
-                this.incomingCallNotification = new CallNotification(payloadString, context);
-                Notification notification = this.incomingCallNotification.build(CallNotification.Style.INCOMING_CALL);
+                this.incomingCallNotification = new IncomingCallNotification(payloadString, context);
+                Notification notification = this.incomingCallNotification.build();
 
                 NotificationManager notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
                 notificationManager.notify(this.incomingCallNotification.getNotificationID(), notification);
@@ -242,6 +244,7 @@ public class MyConnectionService extends ConnectionService {
                 }
                 NotificationManager notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
                 notificationManager.cancel(this.incomingCallNotification.getNotificationID());
+                this.incomingCallNotification = null;
             }
 
             @Override
@@ -257,7 +260,7 @@ public class MyConnectionService extends ConnectionService {
 
                 Log.d(TAG, "Starting CallAudioService...");
                 Intent intent = new Intent(getApplicationContext(), CallAudioService.class);
-                intent.putExtra("pushMessagePayload", payloadString);
+                intent.putExtra("peerName", callerName);
                 startForegroundService(intent);
 
                 Log.d(TAG, "Emitting CordovaCall answer event...");
@@ -321,7 +324,7 @@ public class MyConnectionService extends ConnectionService {
             }
         };
 
-        connection.setCallerDisplayName(payload.optString("from", "UNKNOWN CALLER"), TelecomManager.PRESENTATION_ALLOWED);
+        connection.setCallerDisplayName(callerName, TelecomManager.PRESENTATION_ALLOWED);
 
         Icon icon = CordovaCall.getIcon();
         if(icon != null) {
@@ -406,7 +409,7 @@ public class MyConnectionService extends ConnectionService {
 
         Log.d(TAG, "Starting CallAudioService foreground service...");
         Intent intent = new Intent(getApplicationContext(), CallAudioService.class);
-        intent.putExtra("calleeName", request.getExtras().getString("to"));
+        intent.putExtra("peerName", request.getExtras().getString("to"));
         startForegroundService(intent);
 
         // Set capabilities to indicate this handles audio

--- a/src/android/OngoingCallNotification.java
+++ b/src/android/OngoingCallNotification.java
@@ -60,7 +60,7 @@ public class OngoingCallNotification {
                     .setImportant(true)
                     .build();
 
-            // "CallStyle notifications must be for a foreground service or user initated job or use a fullScreenIntent."
+            // "CallStyle notifications must be for a foreground service or user initiated job or use a fullScreenIntent."
             // NOTE: this requirement is met by the use of a foreground service
             builder.setStyle(NotificationCompat.CallStyle.forOngoingCall(callerPerson, hangupPendingIntent));
         } else {

--- a/src/android/OngoingCallNotification.java
+++ b/src/android/OngoingCallNotification.java
@@ -1,0 +1,90 @@
+package com.dmarc.cordovacall;
+
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.graphics.BitmapFactory;
+import android.os.Build;
+import android.util.Log;
+
+import androidx.core.app.NotificationCompat;
+import androidx.core.app.Person;
+
+import java.util.Random;
+
+
+public class OngoingCallNotification {
+    private static final String TAG = "OngoingCallNotification";
+
+    private String peerName;
+    private Integer notificationID;
+    private Context context;
+    private NotificationManager notificationManager;
+
+    private static final String NOTIFICATION_CHANNEL_ID = "ongoing_calls";
+
+    public OngoingCallNotification(Context context, String peerName) {
+        this.notificationID = new Random().nextInt(100000) + 1;
+        this.context = context;
+        this.notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+
+        this.peerName = peerName;
+
+        this.createNotificationChannel();
+    }
+
+    public Notification build() {
+        Intent hangupIntent = new Intent(this.context, CallActionReceiver.class);
+        hangupIntent.setAction("hangUpCall");
+        hangupIntent.putExtra("notificationID", this.notificationID);
+        PendingIntent hangupPendingIntent = PendingIntent.getBroadcast(
+                this.context, 0, hangupIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE
+        );
+
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(this.context, OngoingCallNotification.NOTIFICATION_CHANNEL_ID)
+                .setContentTitle("Ongoing call")
+                .setSmallIcon(android.R.drawable.ic_menu_call)
+                .setLargeIcon(BitmapFactory.decodeResource(this.context.getResources(), android.R.drawable.sym_def_app_icon))
+                .setPriority(NotificationCompat.PRIORITY_MIN)
+                .setCategory(NotificationCompat.CATEGORY_CALL)
+                .setOngoing(true); // Can't be "dismissed" by the user, app will handle closing it (via notification manager or stopping associated foreground service)
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            Log.d(TAG, "Creating call-style notification for on-going call(as this is supported by the device)...");
+            Person callerPerson = new Person.Builder()
+                    .setName(peerName)
+                    .setImportant(true)
+                    .build();
+
+            // "CallStyle notifications must be for a foreground service or user initated job or use a fullScreenIntent."
+            // NOTE: this requirements is met by the use of a foreground service
+            builder.setStyle(NotificationCompat.CallStyle.forOngoingCall(callerPerson, hangupPendingIntent));
+        } else {
+            builder.setContentText(peerName);
+            builder.addAction(android.R.drawable.ic_menu_call, "Hang up", hangupPendingIntent);
+        }
+
+        Notification notification = builder.build();
+
+        return notification;
+    }
+
+    public int getNotificationID() {
+        return this.notificationID;
+    }
+
+    private void createNotificationChannel() {
+        NotificationChannel channel = new NotificationChannel(
+                OngoingCallNotification.NOTIFICATION_CHANNEL_ID,
+                "Ongoing Calls",
+                NotificationManager.IMPORTANCE_MIN
+        );
+        channel.setDescription("Notifications displayed when in an active call");
+        channel.setSound(null, null);
+        this.notificationManager.createNotificationChannel(channel);
+    }
+}

--- a/src/android/OngoingCallNotification.java
+++ b/src/android/OngoingCallNotification.java
@@ -54,7 +54,7 @@ public class OngoingCallNotification {
                 .setOngoing(true); // Can't be "dismissed" by the user, app will handle closing it (via notification manager or stopping associated foreground service)
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-            Log.d(TAG, "Creating call-style notification for on-going call(as this is supported by the device)...");
+            Log.d(TAG, "Creating call-style notification for on-going call (as this is supported by the device)...");
             Person callerPerson = new Person.Builder()
                     .setName(peerName)
                     .setImportant(true)

--- a/src/android/OngoingCallNotification.java
+++ b/src/android/OngoingCallNotification.java
@@ -61,7 +61,7 @@ public class OngoingCallNotification {
                     .build();
 
             // "CallStyle notifications must be for a foreground service or user initated job or use a fullScreenIntent."
-            // NOTE: this requirements is met by the use of a foreground service
+            // NOTE: this requirement is met by the use of a foreground service
             builder.setStyle(NotificationCompat.CallStyle.forOngoingCall(callerPerson, hangupPendingIntent));
         } else {
             builder.setContentText(peerName);


### PR DESCRIPTION
- Splits CallNotification.java into 2 separate files: IncomingCallNotification.java and OngoingCallNotification.java which simplifies code and avoid un-intended code re-use (which caused a bunch of issues)
- Creates a separate notification channel for on-going call notification which fixes priority issues (causing ongoing notification to be flashed on entering in call page), and avoids associating sounds like the ringtone with on-going call notifications.