### PR TITLE
Call Audio Service Tweaks

### DIFF
--- a/src/android/CallAudioService.java
+++ b/src/android/CallAudioService.java
@@ -24,7 +24,8 @@ public class CallAudioService extends Service {
     public int onStartCommand(Intent intent, int flags, int startId) {
         Log.d(TAG, "onStartCommand");
 
-        // In some cases the OS will start / re-start a service with a n
+        // It's possible for the service to be started with no-intent by the OS,
+        // usually this won't happen though with START_NOT_STICKY
         if (intent == null) {
             Log.e(TAG, "service started with no intent, exiting");
             this.stopSelf();
@@ -57,7 +58,7 @@ public class CallAudioService extends Service {
         audioManager.setMode(AudioManager.MODE_IN_COMMUNICATION);
 
         // Don't auto restart if the app crashes, or the service is killed, etc.
-        // as this may result in the app having no telecom connection but an orphaned CallAudioService.
+        // as this may result in the app having no telecom connection but a orphaned CallAudioService.
         return START_NOT_STICKY;
     }
 

--- a/src/android/CallAudioService.java
+++ b/src/android/CallAudioService.java
@@ -58,7 +58,7 @@ public class CallAudioService extends Service {
         audioManager.setMode(AudioManager.MODE_IN_COMMUNICATION);
 
         // Don't auto restart if the app crashes, or the service is killed, etc.
-        // as this may result in the app having no telecom connection but a orphaned CallAudioService.
+        // as this may result in the app having no telecom connection but an orphaned CallAudioService.
         return START_NOT_STICKY;
     }
 

--- a/src/android/CallAudioService.java
+++ b/src/android/CallAudioService.java
@@ -24,10 +24,15 @@ public class CallAudioService extends Service {
     public int onStartCommand(Intent intent, int flags, int startId) {
         Log.d(TAG, "onStartCommand");
 
-        String peerName = intent != null ? intent.getStringExtra("peerName") : null;
-        if (peerName == null) {
-            peerName = "Unknown";
+        // In some cases the OS will start / re-start a service with a n
+        if (intent == null) {
+            Log.e(TAG, "service started with no intent, exiting");
+            this.stopSelf();
+            return START_NOT_STICKY;
         }
+
+        String peerName = intent.getStringExtra("peerName");
+
         OngoingCallNotification onGoingCallNotification = new OngoingCallNotification(this.getApplicationContext(), peerName);
 
         Notification notification = onGoingCallNotification.build();
@@ -51,7 +56,9 @@ public class CallAudioService extends Service {
         AudioManager audioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
         audioManager.setMode(AudioManager.MODE_IN_COMMUNICATION);
 
-        return START_STICKY;
+        // Don't auto restart if the app crashes, or the service is killed, etc.
+        // as this may result in the app having no telecom connection but an orphaned CallAudioService.
+        return START_NOT_STICKY;
     }
 
     // Note: Although a started service is stopped by a call to either stopSelf() or stopService(),

--- a/src/android/MyConnectionService.java
+++ b/src/android/MyConnectionService.java
@@ -42,7 +42,6 @@ public class MyConnectionService extends ConnectionService {
     static final String TAG = "MyConnectionService";
     private static final ConcurrentHashMap<String, Connection> connectionMap = new ConcurrentHashMap<String, Connection>(); // Keys are call_uuid strings
     private static final ConcurrentHashMap<String, Boolean> connectionAddedMap = new ConcurrentHashMap<String, Boolean>(); // Keys are call_uuid strings, true if addIncomingCall called for the given call uuid.
-    Context context;
 
     private CallActionReceiver callActionReceiver;
 
@@ -108,9 +107,9 @@ public class MyConnectionService extends ConnectionService {
                     if (connectionAddedMap.containsKey(callUUID)) {
                         Log.d(TAG, "A connection was already added for call_uuid: " + callUUID);
                     } else {
-                        TelecomManager tm = (TelecomManager) this.getApplicationContext().getSystemService(Context.TELECOM_SERVICE);
+                        Context context = this.getApplicationContext();
 
-                        context = (Context) this.getApplicationContext();
+                        TelecomManager tm = (TelecomManager) context.getSystemService(Context.TELECOM_SERVICE);
 
                         PhoneAccountHandle phoneAccountHandle = PhoneAccountManager.getPhoneAccountHandle(context);
 
@@ -156,6 +155,7 @@ public class MyConnectionService extends ConnectionService {
 
     public void showWebApp(String userAction, String payload) {
         Log.d(TAG, "showWebApp()");
+        Context context = this.getApplicationContext();
         PackageManager packageManager = context.getPackageManager();
 
         Class mainActivity;
@@ -231,7 +231,7 @@ public class MyConnectionService extends ConnectionService {
                 Log.d(TAG, "onShowIncomingCallUi() invoked, for call_uuid: " + callUUID);
                 this.setRinging();
 
-                this.incomingCallNotification = new IncomingCallNotification(payloadString, context);
+                this.incomingCallNotification = new IncomingCallNotification(payloadString, getApplicationContext());
                 Notification notification = this.incomingCallNotification.build();
 
                 NotificationManager notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
@@ -311,7 +311,8 @@ public class MyConnectionService extends ConnectionService {
                         cancelIncomingCallNotification();
 
                         Log.d(TAG, "Stopping CallAudioService...");
-                        Intent serviceIntent = new Intent(getApplicationContext(), CallAudioService.class);
+                        Context context = getApplicationContext();
+                        Intent serviceIntent = new Intent(context, CallAudioService.class);
                         context.stopService(serviceIntent);
                         break;
                 }
@@ -320,6 +321,7 @@ public class MyConnectionService extends ConnectionService {
                 Intent intent = new Intent("connection_state_changed");
                 intent.putExtra("call_uuid", callUUID);
                 intent.putExtra("state", state);
+                Context context = getApplicationContext();
                 LocalBroadcastManager.getInstance(context).sendBroadcast(intent);
             }
         };
@@ -385,7 +387,8 @@ public class MyConnectionService extends ConnectionService {
                     activeConnectionUUID = null;
 
                     Log.d(TAG, "Stopping CallAudioService foreground service...");
-                    Intent serviceIntent = new Intent(getApplicationContext(), CallAudioService.class);
+                    Context context = getApplicationContext();
+                    Intent serviceIntent = new Intent(context, CallAudioService.class);
                     context.stopService(serviceIntent);
                 }
             }

--- a/src/android/MyConnectionService.java
+++ b/src/android/MyConnectionService.java
@@ -311,7 +311,7 @@ public class MyConnectionService extends ConnectionService {
                         cancelIncomingCallNotification();
 
                         Log.d(TAG, "Stopping CallAudioService...");
-                        Intent serviceIntent = new Intent(context, CallAudioService.class);
+                        Intent serviceIntent = new Intent(getApplicationContext(), CallAudioService.class);
                         context.stopService(serviceIntent);
                         break;
                 }
@@ -377,17 +377,7 @@ public class MyConnectionService extends ConnectionService {
 
             @Override
             public void onStateChanged(int state) {
-                if(state == Connection.STATE_DIALING) {
-                    final Handler handler = new Handler();
-                    handler.postDelayed(new Runnable() {
-                        @Override
-                        public void run() {
-                            Intent intent = new Intent(CordovaCall.getCordova().getActivity().getApplicationContext(), CordovaCall.getCordova().getActivity().getClass());
-                            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK|Intent.FLAG_ACTIVITY_SINGLE_TOP);
-                            CordovaCall.getCordova().getActivity().getApplicationContext().startActivity(intent);
-                        }
-                    }, 500);
-                } else if (state == Connection.STATE_DISCONNECTED) {
+                if (state == Connection.STATE_DISCONNECTED) {
                     // In all cases when connection transitions to STATE_DISCONNECTED (both onAbort() and onDisconnect())
                     // Ensure the connection is destroyed, etc.
                     this.destroy();
@@ -395,7 +385,7 @@ public class MyConnectionService extends ConnectionService {
                     activeConnectionUUID = null;
 
                     Log.d(TAG, "Stopping CallAudioService foreground service...");
-                    Intent serviceIntent = new Intent(context, CallAudioService.class);
+                    Intent serviceIntent = new Intent(getApplicationContext(), CallAudioService.class);
                     context.stopService(serviceIntent);
                 }
             }


### PR DESCRIPTION
- Avoid using START_STICKY as exceptions / crashes in the app (for any reason) result in the foreground service getting re-started by the OS (which puts the app in the state where there is no associated android telecom connection, yet a running foreground service).  (prevents the endlessly re-popping up ongoing call notification issue)
- Handle case where intent is null (OS starts/re-starts the service for any reason)
- Fixes an issue where referencing the MyConnectionService context variable was sometimes never set (null) causing the app to crash