### PR TITLE
Framework for supporting multiple calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-callkit",
-  "version": "1.2.6",
+  "version": "1.3.0",
   "description": "Cordova plugin that lets you use iOS CallKit UI (with PushKit) and Android ConnectionService UI",
   "cordova": {
     "id": "cordova-plugin-callkit",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="cordova-plugin-callkit" version="1.2.6" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="cordova-plugin-callkit" version="1.3.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>Cordova CallKit</name>
 
     <js-module name="VoIPPushNotification" src="www/VoIPPushNotification.js">

--- a/src/ios/CordovaCall.h
+++ b/src/ios/CordovaCall.h
@@ -15,6 +15,7 @@
 // CallKit
 @property (nonatomic, strong) CXProvider *provider;
 @property (nonatomic, strong) CXCallController *callController;
+@property (nonatomic, strong) NSMutableDictionary<NSString *, NSMutableDictionary *> *activeCalls; // Stores each active call, mapped by call ID
 
 - (void)updateProviderConfig;
 - (void)setupAudioSession;
@@ -36,6 +37,16 @@
 - (void)speakerOn:(CDVInvokedUrlCommand*)command;
 - (void)speakerOff:(CDVInvokedUrlCommand*)command;
 - (void)callNumber:(CDVInvokedUrlCommand*)command;
+- (void)dismissRingingCall:(CDVInvokedUrlCommand*)command;
+- (void)keepAlive:(CDVInvokedUrlCommand*)command;
+- (void)stopKeepAlive:(CDVInvokedUrlCommand*)command;
+- (void)keepAliveInBackground:(CDVInvokedUrlCommand*)command;
+- (void)stopKeepAliveInBackground:(CDVInvokedUrlCommand*)command;
+- (void)wsConnect:(CDVInvokedUrlCommand*)command;
+- (void)wsAddListeners:(CDVInvokedUrlCommand*)command;
+- (void)wsSend:(CDVInvokedUrlCommand*)command;
+- (void)wsClose:(CDVInvokedUrlCommand*)command;
+- (void)log:(CDVInvokedUrlCommand*)command;
 
 - (void)receiveCallFromRecents:(NSNotification *) notification;
 - (void)handleAudioRouteChange:(NSNotification *) notification;

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -721,7 +721,12 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 
 // Returns the Callkit CXCall instance for a sessionId
 - (CXCall *)callForSessionId:(NSString *)sessionId {
-    NSUUID *callUUID = self.activeCalls[sessionId][@"callUUID"];
+    if (!sessionId) return nil;
+
+    NSMutableDictionary *call = self.activeCalls[sessionId];
+    if (!call) return nil;
+
+    NSUUID *callUUID = call[@"callUUID"];
     if (!callUUID) return nil;
 
     NSArray<CXCall *> *calls = self.callController.callObserver.calls;

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -20,8 +20,6 @@ BOOL enableDTMF = YES;
 PKPushRegistry *_voipRegistry;
 
 NSString* callBackUrl;
-NSString* callId;
-NSString* callData;
 BOOL isMutedState;
 NSTimer *keepAlive;
 BOOL keepAliveInBackground = NO;
@@ -40,8 +38,8 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     CXProviderConfiguration *providerConfiguration;
     appName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"];
     providerConfiguration = [[CXProviderConfiguration alloc] initWithLocalizedName:appName];
-    providerConfiguration.maximumCallGroups = 1;
-    providerConfiguration.maximumCallsPerCallGroup = 1;
+    providerConfiguration.maximumCallGroups = 1; // Max simultaneous active calls allowed
+    providerConfiguration.maximumCallsPerCallGroup = 1; // Max calls allowed to be handled at once as a group, including held calls
     NSMutableSet *handleTypes = [[NSMutableSet alloc] init];
     [handleTypes addObject:@(CXHandleTypePhoneNumber)];
     providerConfiguration.supportedHandleTypes = handleTypes;
@@ -52,6 +50,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     self.provider = [[CXProvider alloc] initWithConfiguration:providerConfiguration];
     [self.provider setDelegate:self queue:nil];
     self.callController = [[CXCallController alloc] init];
+    self.activeCalls = [[NSMutableDictionary alloc] init];
     //initialize callback dictionary
     callbackIds = [[NSMutableDictionary alloc]initWithCapacity:5];
     [callbackIds setObject:[NSMutableArray array] forKey:@"answer"];
@@ -99,8 +98,8 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 {
     CXProviderConfiguration *providerConfiguration;
     providerConfiguration = [[CXProviderConfiguration alloc] initWithLocalizedName:appName];
-    providerConfiguration.maximumCallGroups = 1;
-    providerConfiguration.maximumCallsPerCallGroup = 1;
+    providerConfiguration.maximumCallGroups = 1; // Max simultaneous active calls allowed
+    providerConfiguration.maximumCallsPerCallGroup = 1; // Max calls allowed to be handled at once as a group, including held calls
     if(ringtone != nil) {
         providerConfiguration.ringtoneSound = ringtone;
     }
@@ -220,7 +219,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     BOOL hasId = ![[command.arguments objectAtIndex:1] isEqual:[NSNull null]];
     NSString* callName = [command.arguments objectAtIndex:0];
     NSString* callId = hasId?[command.arguments objectAtIndex:1]:callName;
-    NSUUID *callUUID = [[NSUUID alloc] init];
+    NSUUID *callUUID = self.activeCalls[callId][@"callUUID"];
 
     if (hasId) {
         [[NSUserDefaults standardUserDefaults] setObject:callName forKey:[command.arguments objectAtIndex:1]];
@@ -242,6 +241,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
                 [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Incoming call successful"] callbackId:command.callbackId];
             } else {
                 [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:[error localizedDescription]] callbackId:command.callbackId];
+                return;
             }
         }];
         for (id callbackId in callbackIds[@"receiveCall"]) {
@@ -261,8 +261,12 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     BOOL hasId = ![[command.arguments objectAtIndex:1] isEqual:[NSNull null]];
     NSString* callName = [command.arguments objectAtIndex:0];
     NSString* callId = hasId?[command.arguments objectAtIndex:1]:callName;
+    NSString* sessionId = [command.arguments objectAtIndex:2];
     NSUUID *callUUID = [[NSUUID alloc] init];
-
+    self.activeCalls[sessionId] = [@{
+        @"callUUID": callUUID
+    } mutableCopy];
+    
     if (hasId) {
         [[NSUserDefaults standardUserDefaults] setObject:callName forKey:[command.arguments objectAtIndex:1]];
         [[NSUserDefaults standardUserDefaults] synchronize];
@@ -290,10 +294,11 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 {
     [self logMessage:@"connectCall"];
     CDVPluginResult* pluginResult = nil;
-    NSArray<CXCall *> *calls = self.callController.callObserver.calls;
+    NSString* callId = [command.arguments objectAtIndex:0];
+    CXCall *call = [self callForCallId:callId];
 
-    if([calls count] == 1 && !calls[0].hasConnected) {
-        [self.provider reportOutgoingCallWithUUID:calls[0].UUID connectedAtDate:nil];
+    if(call && !call.hasConnected) {
+        [self.provider reportOutgoingCallWithUUID:call.UUID connectedAtDate:nil];
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Call connected successfully"];
     } else {
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"No call exists for you to connect"];
@@ -307,10 +312,11 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     [self logMessage:@"endCall"];
     [self stopKeepAlive:nil];
     CDVPluginResult* pluginResult = nil;
-    NSArray<CXCall *> *calls = self.callController.callObserver.calls;
+    NSString* callId = [command.arguments objectAtIndex:0];
+    CXCall *call = [self callForCallId:callId];
 
-    if([calls count] == 1) {
-        CXEndCallAction *endCallAction = [[CXEndCallAction alloc] initWithCallUUID:calls[0].UUID];
+    if(call) {
+        CXEndCallAction *endCallAction = [[CXEndCallAction alloc] initWithCallUUID:call.UUID];
         CXTransaction *transaction = [[CXTransaction alloc] initWithAction:endCallAction];
         [self.callController requestTransaction:transaction completion:^(NSError * _Nullable error) {
             if (error == nil) {
@@ -341,13 +347,21 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     }
     
     // In case of registerEvent answer or reject called after responding to call, trigger cordova event for the appropriate answer
-    if ([eventName isEqualToString:@"answer"] && [pendingCallResponses containsObject:PENDING_RESPONSE_ANSWER]) {
-        [self triggerCordovaEventForCallResponse:@"answer"];
-        [pendingCallResponses removeObject:PENDING_RESPONSE_ANSWER];
+    if ([eventName isEqualToString:@"answer"]) {
+        // Gets all of the pending answer call responses, actions on each one and then deletes them all from pendingCallResponses
+        NSArray *answers = [pendingCallResponses filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"type == %@", PENDING_RESPONSE_ANSWER]];
+        for (NSDictionary *answer in answers) {
+            [self triggerCordovaEventForCallResponse:@"answer" callId:answer[@"callId"]];
+        }
+        [pendingCallResponses removeObjectsInArray:answers];
     }
-    if ([eventName isEqualToString:@"reject"] && [pendingCallResponses containsObject:PENDING_RESPONSE_REJECT]) {
-        [self triggerCordovaEventForCallResponse:@"reject"];
-        [pendingCallResponses removeObject:PENDING_RESPONSE_REJECT];
+    if ([eventName isEqualToString:@"reject"]) {
+        // Gets all of the pending reject call responses, actions on each one and then deletes them all from pendingCallResponses
+        NSArray *rejects = [pendingCallResponses filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"type == %@", PENDING_RESPONSE_REJECT]];
+        for (NSDictionary *reject in rejects) {
+            [self triggerCordovaEventForCallResponse:@"reject" callId:reject[@"callId"]];
+        }
+        [pendingCallResponses removeObjectsInArray:rejects];
     }
 }
 
@@ -355,9 +369,10 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 {
     [self logMessage:@"mute"];
     __block CDVPluginResult* pluginResult = nil;
-    NSArray<CXCall *> *calls = self.callController.callObserver.calls;
-    if ([calls count] == 1) {
-        CXSetMutedCallAction *muteAction = [[CXSetMutedCallAction alloc] initWithCallUUID:calls[0].UUID muted:YES];
+    NSString* callId = [command.arguments objectAtIndex:0];
+    CXCall *call = [self callForCallId:callId];
+    if (call) {
+        CXSetMutedCallAction *muteAction = [[CXSetMutedCallAction alloc] initWithCallUUID:call.UUID muted:YES];
         CXTransaction *transaction = [[CXTransaction alloc] initWithAction:muteAction];
         [self logMessage:@"Programatically Muting Call"];
         [self.callController requestTransaction:transaction completion:^(NSError * _Nullable error) {
@@ -381,9 +396,10 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 {
     [self logMessage:@"unmute"];
     __block CDVPluginResult* pluginResult = nil;
-    NSArray<CXCall *> *calls = self.callController.callObserver.calls;
-    if ([calls count] == 1) {
-        CXSetMutedCallAction *unmuteAction = [[CXSetMutedCallAction alloc] initWithCallUUID:calls[0].UUID muted:NO];
+    NSString* callId = [command.arguments objectAtIndex:0];
+    CXCall *call = [self callForCallId:callId];
+    if (call) {
+        CXSetMutedCallAction *unmuteAction = [[CXSetMutedCallAction alloc] initWithCallUUID:call.UUID muted:NO];
         CXTransaction *transaction = [[CXTransaction alloc] initWithAction:unmuteAction];
         [self logMessage:@"Programatically Unmuting Call"];
         [self.callController requestTransaction:transaction completion:^(NSError * _Nullable error) {
@@ -553,11 +569,16 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     [self setupAudioSession];
     [action fulfill];
 
+    NSString *callId = [self callIdForUUID:action.callUUID];
     if ([callbackIds[@"answer"] count] == 0) {
         // callbackId for event not registered, add to pending to trigger on registration
-        [pendingCallResponses addObject:PENDING_RESPONSE_ANSWER];
+        NSDictionary *pendingResponse = @{
+            @"type": PENDING_RESPONSE_ANSWER,
+            @"callId": callId
+        };
+        [pendingCallResponses addObject:pendingResponse];
     } else {
-        [self triggerCordovaEventForCallResponse:@"answer"];
+        [self triggerCordovaEventForCallResponse:@"answer" callId:callId];
     }
 
     UIApplication *app = [UIApplication sharedApplication];
@@ -576,9 +597,10 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 {
     [self logMessage:@"performEndCallAction"];
     [self stopKeepAlive:nil];
-    NSArray<CXCall *> *calls = self.callController.callObserver.calls;
-    if([calls count] == 1) {
-        if(calls[0].hasConnected) {
+    NSString *callId = [self callIdForUUID:action.callUUID];
+    CXCall *call = [self callForCallId:callId];
+    if(call) {
+        if(call.hasConnected) {
             for (id callbackId in callbackIds[@"hangup"]) {
                 CDVPluginResult* pluginResult = nil;
                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"hangup event called successfully"];
@@ -588,24 +610,28 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         } else {
             if ([callbackIds[@"reject"] count] == 0) {
                 // callbackId for event not registered, add to pending to trigger on registration
-                [pendingCallResponses addObject:PENDING_RESPONSE_REJECT];
+                NSDictionary *pendingResponse = @{
+                    @"type": PENDING_RESPONSE_REJECT,
+                    @"callId": callId
+                };
+                [pendingCallResponses addObject:pendingResponse];
             } else {
-                [self triggerCordovaEventForCallResponse:@"reject"];
+                [self triggerCordovaEventForCallResponse:@"reject" callId:callId];
             }
         }
+        [self.activeCalls removeObjectForKey:callId]; // clear out the call once it's ended
     }
     monitorAudioRouteChange = NO;
     [action fulfill];
 }
 
-- (void)triggerCordovaEventForCallResponse:(NSString*) response {
+- (void)triggerCordovaEventForCallResponse:(NSString*) response callId:(NSString*)callId {
     if ([@[@"answer", @"reject"] containsObject:response]) {
         for (id callbackId in callbackIds[response]) {
-            CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:callData];
+            CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:self.activeCalls[callId][@"callData"]];
             [pluginResult setKeepCallbackAsBool:YES];
             [self.commandDelegate sendPluginResult:pluginResult callbackId:callbackId];
         }
-        callData = nil; // clear out the Call Data in case CordovaCall.receiveCall('caller'); called from JS side
     }
 }
 
@@ -647,7 +673,8 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 {
     [self logMessage:@"dismissRingingCall"];
     
-    BOOL didDismiss = [self _dismissRingingCall];
+    NSString *callId = [command.arguments objectAtIndex:0];
+    BOOL didDismiss = [self _dismissRingingCall:callId];
     CDVPluginResult* pluginResult = nil;
     if (didDismiss) {
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
@@ -661,15 +688,42 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 }
 
 // Internal method that can be called from within the plugin
-- (BOOL)_dismissRingingCall {
+- (BOOL)_dismissRingingCall:(NSString *)callId {
     [self logMessage:@"_dismissRingingCall"];
 
-    NSArray<CXCall *> *calls = self.callController.callObserver.calls;
-    if ([calls count] == 1 && !calls[0].hasConnected) {
-        [self.provider reportCallWithUUID:calls[0].UUID endedAtDate:nil reason:CXCallEndedReasonRemoteEnded];
+    CXCall *call = [self callForCallId:callId];
+    if (call && !call.hasConnected) {
+        [self.provider reportCallWithUUID:call.UUID endedAtDate:nil reason:CXCallEndedReasonRemoteEnded];
         return YES;
     }
     return NO;
+}
+
+// Returns the Callkit CXCall instance for a callId/sessionId
+- (CXCall *)callForCallId:(NSString *)callId {
+    NSUUID *callUUID = self.activeCalls[callId][@"callUUID"];
+    if (!callUUID) return nil;
+
+    NSArray<CXCall *> *calls = self.callController.callObserver.calls;
+    for (CXCall *call in calls) {
+        if ([call.UUID isEqual:callUUID]) {
+            return call;
+        }
+    }
+    return nil;
+}
+
+// Maps the callkit internal callUUID with the facetalk callId/sessionId
+// Needed because answering and rejecting from callkit UI returns only callkit internal callUUID
+- (nullable NSString *)callIdForUUID:(NSUUID *)callUUID {
+    if (!callUUID) return nil;
+
+    for (NSString *callId in self.activeCalls) {
+        if ([self.activeCalls[callId][@"callUUID"] isEqual:callUUID]) {
+            return callId;
+        }
+    }
+    return nil;
 }
 
 - (void) log:(CDVInvokedUrlCommand*)command
@@ -903,15 +957,19 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         [self logMessage:[NSString stringWithFormat:@"Error parsing payload JSON: %@", error]];
         return;
     }
-    NSArray* args = [NSArray arrayWithObjects:[payloadObj valueForKey:@"from"], [payloadObj valueForKey:@"call_uuid"], nil];
+    // call_id is the first part of the call_uuid separated by ;  IE: call_id;ftag;ttag
+    NSString *callId = [[[payloadObj valueForKey:@"call_uuid"] componentsSeparatedByString:@";"] firstObject];
+    NSArray* args = [NSArray arrayWithObjects:[payloadObj valueForKey:@"from"], callId, nil];
     CDVInvokedUrlCommand* newCommand = [[CDVInvokedUrlCommand alloc] initWithArguments:args callbackId:@"" className:self.VoIPPushClassName methodName:self.VoIPPushMethodName];
     
     // Store URL and Call Id so they can be used for call Answer/Reject
     callBackUrl = [payloadObj valueForKey:@"callback_url"];
-    callId = [payloadObj valueForKey:@"call_uuid"];
     NSString *Type = [payloadObj valueForKey:@"type"];
     hasVideo = ![Type isEqualToString:@"incoming_phone_call"];
-    callData = [data valueForKey:@"payload"];
+    self.activeCalls[callId] = [@{
+        @"callData": [[NSString alloc] initWithData:payloadJsonData encoding:NSUTF8StringEncoding],
+        @"callUUID": [[NSUUID alloc] init]
+    } mutableCopy];
     // Notify Webhook that VOIP Push Has been received and app is started
     // NSURL *statusUpdateUrl = [NSURL URLWithString:[NSString stringWithFormat:@"%@?id=%@&input=%@", callBackUrl, callId, @"connected"]];
     // NSURLSession *session = [NSURLSession sharedSession];
@@ -972,7 +1030,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         [self logMessage:@"Dismiss key not found in payload or is false"];
         return;
     } else {
-        [self _dismissRingingCall];
+        [self _dismissRingingCall:payloadDict[@"call_uuid"]];
     }
 }
 

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -984,7 +984,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     }
     // sessionId is the first part of the call_uuid separated by ;  IE: call_id;ftag;ttag
     NSString *sessionId = [[[payloadObj valueForKey:@"call_uuid"] componentsSeparatedByString:@";"] firstObject];
-    NSArray* args = [NSArray arrayWithObjects:[payloadObj valueForKey:@"from"], nil, sessionId, nil];
+    NSArray* args = [NSArray arrayWithObjects:[payloadObj valueForKey:@"from"], [NSNull null], sessionId, nil];
     CDVInvokedUrlCommand* newCommand = [[CDVInvokedUrlCommand alloc] initWithArguments:args callbackId:@"" className:self.VoIPPushClassName methodName:self.VoIPPushMethodName];
     
     // Store URL and Call Id so they can be used for call Answer/Reject

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -984,7 +984,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     }
     // sessionId is the first part of the call_uuid separated by ;  IE: call_id;ftag;ttag
     NSString *sessionId = [[[payloadObj valueForKey:@"call_uuid"] componentsSeparatedByString:@";"] firstObject];
-    NSArray* args = [NSArray arrayWithObjects:[payloadObj valueForKey:@"from"], nil, sessionId];
+    NSArray* args = [NSArray arrayWithObjects:[payloadObj valueForKey:@"from"], nil, sessionId, nil];
     CDVInvokedUrlCommand* newCommand = [[CDVInvokedUrlCommand alloc] initWithArguments:args callbackId:@"" className:self.VoIPPushClassName methodName:self.VoIPPushMethodName];
     
     // Store URL and Call Id so they can be used for call Answer/Reject

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -218,7 +218,22 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     BOOL hasId = ![[command.arguments objectAtIndex:1] isEqual:[NSNull null]];
     NSString* callName = [command.arguments objectAtIndex:0];
     NSString* callId = hasId?[command.arguments objectAtIndex:1]:callName;
-    NSUUID *callUUID = self.activeCalls[callId][@"callUUID"];
+    NSString* sessionId = [command.arguments objectAtIndex:2];
+    // We must always be provided a sessionId because we need to identify the call
+    if (sessionId == nil) {
+        [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"sessionId cannot be nil"] callbackId:command.callbackId];
+        return;
+    }
+
+    // If this was called from JS, we'll need to create a new activeCall entry
+    NSMutableDictionary *call = self.activeCalls[sessionId];
+    if (!call) {
+        self.activeCalls[sessionId] = [@{
+            @"callUUID": [[NSUUID alloc] init],
+            @"muted": @NO
+        } mutableCopy];
+    }
+    NSUUID *callUUID = self.activeCalls[sessionId][@"callUUID"];
 
     if (hasId) {
         [[NSUserDefaults standardUserDefaults] setObject:callName forKey:[command.arguments objectAtIndex:1]];
@@ -294,8 +309,8 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 {
     [self logMessage:@"connectCall"];
     CDVPluginResult* pluginResult = nil;
-    NSString* callId = [command.arguments objectAtIndex:0];
-    CXCall *call = [self callForCallId:callId];
+    NSString* sessionId = [command.arguments objectAtIndex:0];
+    CXCall *call = [self callForSessionId:sessionId];
 
     if(call && !call.hasConnected) {
         [self.provider reportOutgoingCallWithUUID:call.UUID connectedAtDate:nil];
@@ -312,8 +327,8 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     [self logMessage:@"endCall"];
     [self stopKeepAlive:nil];
     CDVPluginResult* pluginResult = nil;
-    NSString* callId = [command.arguments objectAtIndex:0];
-    CXCall *call = [self callForCallId:callId];
+    NSString* sessionId = [command.arguments objectAtIndex:0];
+    CXCall *call = [self callForSessionId:sessionId];
 
     if(call) {
         CXEndCallAction *endCallAction = [[CXEndCallAction alloc] initWithCallUUID:call.UUID];
@@ -351,7 +366,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         // Gets all of the pending answer call responses, actions on each one and then deletes them all from pendingCallResponses
         NSArray *answers = [pendingCallResponses filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"type == %@", PENDING_RESPONSE_ANSWER]];
         for (NSDictionary *answer in answers) {
-            [self triggerCordovaEventForCallResponse:@"answer" callId:answer[@"callId"]];
+            [self triggerCordovaEventForCallResponse:@"answer" sessionId:answer[@"sessionId"]];
         }
         [pendingCallResponses removeObjectsInArray:answers];
     }
@@ -359,7 +374,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         // Gets all of the pending reject call responses, actions on each one and then deletes them all from pendingCallResponses
         NSArray *rejects = [pendingCallResponses filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"type == %@", PENDING_RESPONSE_REJECT]];
         for (NSDictionary *reject in rejects) {
-            [self triggerCordovaEventForCallResponse:@"reject" callId:reject[@"callId"]];
+            [self triggerCordovaEventForCallResponse:@"reject" sessionId:reject[@"sessionId"]];
         }
         [pendingCallResponses removeObjectsInArray:rejects];
     }
@@ -369,19 +384,19 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 {
     [self logMessage:@"mute"];
     __block CDVPluginResult* pluginResult = nil;
-    NSString* callId = [command.arguments objectAtIndex:0];
-    CXCall *call = [self callForCallId:callId];
+    NSString* sessionId = [command.arguments objectAtIndex:0];
+    CXCall *call = [self callForSessionId:sessionId];
     if (call) {
         CXSetMutedCallAction *muteAction = [[CXSetMutedCallAction alloc] initWithCallUUID:call.UUID muted:YES];
         CXTransaction *transaction = [[CXTransaction alloc] initWithAction:muteAction];
         [self logMessage:@"Programatically Muting Call"];
         [self.callController requestTransaction:transaction completion:^(NSError * _Nullable error) {
             if (error == nil) {
-                self.activeCalls[callId][@"muted"] = @YES;
+                self.activeCalls[sessionId][@"muted"] = @YES;
                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Muted Successfully"];
             } else {
             [self logMessage:@"Error occurred muting Call"];
-                self.activeCalls[callId][@"muted"] = @NO;
+                self.activeCalls[sessionId][@"muted"] = @NO;
                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"An error occurred"];
             }
             [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
@@ -396,19 +411,19 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 {
     [self logMessage:@"unmute"];
     __block CDVPluginResult* pluginResult = nil;
-    NSString* callId = [command.arguments objectAtIndex:0];
-    CXCall *call = [self callForCallId:callId];
+    NSString* sessionId = [command.arguments objectAtIndex:0];
+    CXCall *call = [self callForSessionId:sessionId];
     if (call) {
         CXSetMutedCallAction *unmuteAction = [[CXSetMutedCallAction alloc] initWithCallUUID:call.UUID muted:NO];
         CXTransaction *transaction = [[CXTransaction alloc] initWithAction:unmuteAction];
         [self logMessage:@"Programatically Unmuting Call"];
         [self.callController requestTransaction:transaction completion:^(NSError * _Nullable error) {
             if (error == nil) {
-                self.activeCalls[callId][@"muted"] = @NO;
+                self.activeCalls[sessionId][@"muted"] = @NO;
                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Unmuted Successfully"];
             } else {
             [self logMessage:@"Error occurred unmuting Call"];
-                self.activeCalls[callId][@"muted"] = @YES;
+                self.activeCalls[sessionId][@"muted"] = @YES;
                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"An error occurred"];
             }
             [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
@@ -569,16 +584,16 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     [self setupAudioSession];
     [action fulfill];
 
-    NSString *callId = [self callIdForUUID:action.callUUID];
+    NSString *sessionId = [self sessionIdForUUID:action.callUUID];
     if ([callbackIds[@"answer"] count] == 0) {
         // callbackId for event not registered, add to pending to trigger on registration
         NSDictionary *pendingResponse = @{
             @"type": PENDING_RESPONSE_ANSWER,
-            @"callId": callId
+            @"sessionId": sessionId
         };
         [pendingCallResponses addObject:pendingResponse];
     } else {
-        [self triggerCordovaEventForCallResponse:@"answer" callId:callId];
+        [self triggerCordovaEventForCallResponse:@"answer" sessionId:sessionId];
     }
 
     UIApplication *app = [UIApplication sharedApplication];
@@ -597,14 +612,14 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 {
     [self logMessage:@"performEndCallAction"];
     [self stopKeepAlive:nil];
-    NSString *callId = [self callIdForUUID:action.callUUID];
-    CXCall *call = [self callForCallId:callId];
+    NSString *sessionId = [self sessionIdForUUID:action.callUUID];
+    CXCall *call = [self callForSessionId:sessionId];
     if(call) {
         if(call.hasConnected) {
             for (id callbackId in callbackIds[@"hangup"]) {
                 CDVPluginResult* pluginResult = nil;
                 // Send to facetalk whihc call was ended
-                NSDictionary *resultDict = @{ @"message": @"hangup event called successfully", @"sessionId": callId };
+                NSDictionary *resultDict = @{ @"message": @"hangup event called successfully", @"sessionId": sessionId };
                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:resultDict];
                 [pluginResult setKeepCallbackAsBool:YES];
                 [self.commandDelegate sendPluginResult:pluginResult callbackId:callbackId];
@@ -614,23 +629,23 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
                 // callbackId for event not registered, add to pending to trigger on registration
                 NSDictionary *pendingResponse = @{
                     @"type": PENDING_RESPONSE_REJECT,
-                    @"callId": callId
+                    @"sessionId": sessionId
                 };
                 [pendingCallResponses addObject:pendingResponse];
             } else {
-                [self triggerCordovaEventForCallResponse:@"reject" callId:callId];
+                [self triggerCordovaEventForCallResponse:@"reject" sessionId:sessionId];
             }
         }
-        [self.activeCalls removeObjectForKey:callId]; // clear out the call once it's ended
+        [self.activeCalls removeObjectForKey:sessionId]; // clear out the call once it's ended
     }
     monitorAudioRouteChange = NO;
     [action fulfill];
 }
 
-- (void)triggerCordovaEventForCallResponse:(NSString*) response callId:(NSString*)callId {
+- (void)triggerCordovaEventForCallResponse:(NSString*) response sessionId:(NSString*)sessionId {
     if ([@[@"answer", @"reject"] containsObject:response]) {
         for (id callbackId in callbackIds[response]) {
-            CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:self.activeCalls[callId][@"callData"]];
+            CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:self.activeCalls[sessionId][@"callData"]];
             [pluginResult setKeepCallbackAsBool:YES];
             [self.commandDelegate sendPluginResult:pluginResult callbackId:callbackId];
         }
@@ -640,21 +655,21 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 - (void)provider:(CXProvider *)provider performSetMutedCallAction:(CXSetMutedCallAction *)action
 {
     BOOL isMuted = action.muted;
-    NSString *callId = [self callIdForUUID:action.callUUID];
-    [self logMessage:[NSString stringWithFormat:@"Callkit UI received %@ event, currently %@", isMuted ? @"mute" : @"unmute", [self.activeCalls[callId][@"muted"] boolValue] ? @"muted" : @"unmuted"]];
+    NSString *sessionId = [self sessionIdForUUID:action.callUUID];
+    [self logMessage:[NSString stringWithFormat:@"Callkit UI received %@ event, currently %@", isMuted ? @"mute" : @"unmute", [self.activeCalls[sessionId][@"muted"] boolValue] ? @"muted" : @"unmuted"]];
     [action fulfill];
 
     // Ignore the duplicate mute/unmute events, somehow 2 events get sent for every action
-    if ([self.activeCalls[callId][@"muted"] boolValue] == isMuted) {
+    if ([self.activeCalls[sessionId][@"muted"] boolValue] == isMuted) {
         [self logMessage:[NSString stringWithFormat:@"Ignoring duplicate %@ event.", isMuted ? @"mute" : @"unmute"]];
         return;
     }
-    self.activeCalls[callId][@"muted"] = @(isMuted); // Update the internal state with the new value
+    self.activeCalls[sessionId][@"muted"] = @(isMuted); // Update the internal state with the new value
     for (id callbackId in callbackIds[isMuted?@"mute":@"unmute"]) {
         [self logMessage:[NSString stringWithFormat:@"Sending %@ event to JS", isMuted ? @"mute" : @"unmute"]];
         CDVPluginResult* pluginResult = nil;
         // Send to facetalk which call was muted/unmuted
-        NSDictionary *resultDict = @{ @"message": [NSString stringWithFormat:@"%@ event called successfully", isMuted ? @"mute" : @"unmute"], @"sessionId": callId };
+        NSDictionary *resultDict = @{ @"message": [NSString stringWithFormat:@"%@ event called successfully", isMuted ? @"mute" : @"unmute"], @"sessionId": sessionId };
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:resultDict];
         [pluginResult setKeepCallbackAsBool:YES];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:callbackId];
@@ -678,8 +693,8 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 {
     [self logMessage:@"dismissRingingCall"];
     
-    NSString *callId = [command.arguments objectAtIndex:0];
-    BOOL didDismiss = [self _dismissRingingCall:callId];
+    NSString *sessionId = [command.arguments objectAtIndex:0];
+    BOOL didDismiss = [self _dismissRingingCall:sessionId];
     CDVPluginResult* pluginResult = nil;
     if (didDismiss) {
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
@@ -693,10 +708,10 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 }
 
 // Internal method that can be called from within the plugin
-- (BOOL)_dismissRingingCall:(NSString *)callId {
+- (BOOL)_dismissRingingCall:(NSString *)sessionId {
     [self logMessage:@"_dismissRingingCall"];
 
-    CXCall *call = [self callForCallId:callId];
+    CXCall *call = [self callForSessionId:sessionId];
     if (call && !call.hasConnected) {
         [self.provider reportCallWithUUID:call.UUID endedAtDate:nil reason:CXCallEndedReasonRemoteEnded];
         return YES;
@@ -704,9 +719,9 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     return NO;
 }
 
-// Returns the Callkit CXCall instance for a callId/sessionId
-- (CXCall *)callForCallId:(NSString *)callId {
-    NSUUID *callUUID = self.activeCalls[callId][@"callUUID"];
+// Returns the Callkit CXCall instance for a sessionId
+- (CXCall *)callForSessionId:(NSString *)sessionId {
+    NSUUID *callUUID = self.activeCalls[sessionId][@"callUUID"];
     if (!callUUID) return nil;
 
     NSArray<CXCall *> *calls = self.callController.callObserver.calls;
@@ -718,14 +733,14 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     return nil;
 }
 
-// Maps the callkit internal callUUID with the facetalk callId/sessionId
+// Maps the callkit internal callUUID with the facetalk sessionId
 // Needed because any actions from callkit UI returns only callkit internal callUUID
-- (nullable NSString *)callIdForUUID:(NSUUID *)callUUID {
+- (nullable NSString *)sessionIdForUUID:(NSUUID *)callUUID {
     if (!callUUID) return nil;
 
-    for (NSString *callId in self.activeCalls) {
-        if ([self.activeCalls[callId][@"callUUID"] isEqual:callUUID]) {
-            return callId;
+    for (NSString *sessionId in self.activeCalls) {
+        if ([self.activeCalls[sessionId][@"callUUID"] isEqual:callUUID]) {
+            return sessionId;
         }
     }
     return nil;
@@ -962,16 +977,16 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         [self logMessage:[NSString stringWithFormat:@"Error parsing payload JSON: %@", error]];
         return;
     }
-    // call_id is the first part of the call_uuid separated by ;  IE: call_id;ftag;ttag
-    NSString *callId = [[[payloadObj valueForKey:@"call_uuid"] componentsSeparatedByString:@";"] firstObject];
-    NSArray* args = [NSArray arrayWithObjects:[payloadObj valueForKey:@"from"], callId, nil];
+    // sessionId is the first part of the call_uuid separated by ;  IE: call_id;ftag;ttag
+    NSString *sessionId = [[[payloadObj valueForKey:@"call_uuid"] componentsSeparatedByString:@";"] firstObject];
+    NSArray* args = [NSArray arrayWithObjects:[payloadObj valueForKey:@"from"], nil, sessionId];
     CDVInvokedUrlCommand* newCommand = [[CDVInvokedUrlCommand alloc] initWithArguments:args callbackId:@"" className:self.VoIPPushClassName methodName:self.VoIPPushMethodName];
     
     // Store URL and Call Id so they can be used for call Answer/Reject
     callBackUrl = [payloadObj valueForKey:@"callback_url"];
     NSString *Type = [payloadObj valueForKey:@"type"];
     hasVideo = ![Type isEqualToString:@"incoming_phone_call"];
-    self.activeCalls[callId] = [@{
+    self.activeCalls[sessionId] = [@{
         @"callData": [[NSString alloc] initWithData:payloadJsonData encoding:NSUTF8StringEncoding],
         @"callUUID": [[NSUUID alloc] init],
         @"muted": @NO

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -20,7 +20,6 @@ BOOL enableDTMF = YES;
 PKPushRegistry *_voipRegistry;
 
 NSString* callBackUrl;
-BOOL isMutedState;
 NSTimer *keepAlive;
 BOOL keepAliveInBackground = NO;
 double keepAliveInterval = 0.2;
@@ -264,7 +263,8 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     NSString* sessionId = [command.arguments objectAtIndex:2];
     NSUUID *callUUID = [[NSUUID alloc] init];
     self.activeCalls[sessionId] = [@{
-        @"callUUID": callUUID
+        @"callUUID": callUUID,
+        @"muted": @NO
     } mutableCopy];
     
     if (hasId) {
@@ -377,11 +377,11 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         [self logMessage:@"Programatically Muting Call"];
         [self.callController requestTransaction:transaction completion:^(NSError * _Nullable error) {
             if (error == nil) {
-                isMutedState = YES;
+                self.activeCalls[callId][@"muted"] = @YES;
                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Muted Successfully"];
             } else {
             [self logMessage:@"Error occurred muting Call"];
-                isMutedState = NO;
+                self.activeCalls[callId][@"muted"] = @NO;
                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"An error occurred"];
             }
             [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
@@ -404,11 +404,11 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         [self logMessage:@"Programatically Unmuting Call"];
         [self.callController requestTransaction:transaction completion:^(NSError * _Nullable error) {
             if (error == nil) {
-                isMutedState = NO;
+                self.activeCalls[callId][@"muted"] = @NO;
                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Unmuted Successfully"];
             } else {
             [self logMessage:@"Error occurred unmuting Call"];
-                isMutedState = YES;
+                self.activeCalls[callId][@"muted"] = @YES;
                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"An error occurred"];
             }
             [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
@@ -603,7 +603,9 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         if(call.hasConnected) {
             for (id callbackId in callbackIds[@"hangup"]) {
                 CDVPluginResult* pluginResult = nil;
-                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"hangup event called successfully"];
+                // Send to facetalk whihc call was ended
+                NSDictionary *resultDict = @{ @"message": @"hangup event called successfully", @"sessionId": callId };
+                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:resultDict];
                 [pluginResult setKeepCallbackAsBool:YES];
                 [self.commandDelegate sendPluginResult:pluginResult callbackId:callbackId];
             }
@@ -638,19 +640,22 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 - (void)provider:(CXProvider *)provider performSetMutedCallAction:(CXSetMutedCallAction *)action
 {
     BOOL isMuted = action.muted;
-    [self logMessage:[NSString stringWithFormat:@"Callkit UI received %@ event, currently %@", isMuted ? @"mute" : @"unmute", isMutedState ? @"muted" : @"unmuted"]];
+    NSString *callId = [self callIdForUUID:action.callUUID];
+    [self logMessage:[NSString stringWithFormat:@"Callkit UI received %@ event, currently %@", isMuted ? @"mute" : @"unmute", [self.activeCalls[callId][@"muted"] boolValue] ? @"muted" : @"unmuted"]];
     [action fulfill];
 
     // Ignore the duplicate mute/unmute events, somehow 2 events get sent for every action
-    if (isMutedState == isMuted) {
+    if ([self.activeCalls[callId][@"muted"] boolValue] == isMuted) {
         [self logMessage:[NSString stringWithFormat:@"Ignoring duplicate %@ event.", isMuted ? @"mute" : @"unmute"]];
         return;
     }
-    isMutedState = isMuted ? YES : NO; // Update the internal state with the new value
+    self.activeCalls[callId][@"muted"] = @(isMuted); // Update the internal state with the new value
     for (id callbackId in callbackIds[isMuted?@"mute":@"unmute"]) {
         [self logMessage:[NSString stringWithFormat:@"Sending %@ event to JS", isMuted ? @"mute" : @"unmute"]];
         CDVPluginResult* pluginResult = nil;
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:[NSString stringWithFormat:@"%@ event called successfully", isMuted ? @"mute" : @"unmute"]];
+        // Send to facetalk which call was muted/unmuted
+        NSDictionary *resultDict = @{ @"message": [NSString stringWithFormat:@"%@ event called successfully", isMuted ? @"mute" : @"unmute"], @"sessionId": callId };
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:resultDict];
         [pluginResult setKeepCallbackAsBool:YES];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:callbackId];
     }
@@ -714,7 +719,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 }
 
 // Maps the callkit internal callUUID with the facetalk callId/sessionId
-// Needed because answering and rejecting from callkit UI returns only callkit internal callUUID
+// Needed because any actions from callkit UI returns only callkit internal callUUID
 - (nullable NSString *)callIdForUUID:(NSUUID *)callUUID {
     if (!callUUID) return nil;
 
@@ -968,7 +973,8 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     hasVideo = ![Type isEqualToString:@"incoming_phone_call"];
     self.activeCalls[callId] = [@{
         @"callData": [[NSString alloc] initWithData:payloadJsonData encoding:NSUTF8StringEncoding],
-        @"callUUID": [[NSUUID alloc] init]
+        @"callUUID": [[NSUUID alloc] init],
+        @"muted": @NO
     } mutableCopy];
     // Notify Webhook that VOIP Push Has been received and app is started
     // NSURL *statusUpdateUrl = [NSURL URLWithString:[NSString stringWithFormat:@"%@?id=%@&input=%@", callBackUrl, callId, @"connected"]];

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -982,8 +982,8 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         [self logMessage:[NSString stringWithFormat:@"Error parsing payload JSON: %@", error]];
         return;
     }
-    // sessionId is the first part of the call_uuid separated by ;  IE: call_id;ftag;ttag
-    NSString *sessionId = [[[payloadObj valueForKey:@"call_uuid"] componentsSeparatedByString:@";"] firstObject];
+    // session_id param is the parsed call_uuid for NS PBX calls, it's session_id = callId + ftag, where call_uuid = callId;ftag;ttag
+    NSString *sessionId = [payloadObj valueForKey:@"session_id"] ?: [payloadObj valueForKey:@"call_uuid"];
     NSArray* args = [NSArray arrayWithObjects:[payloadObj valueForKey:@"from"], [NSNull null], sessionId, nil];
     CDVInvokedUrlCommand* newCommand = [[CDVInvokedUrlCommand alloc] initWithArguments:args callbackId:@"" className:self.VoIPPushClassName methodName:self.VoIPPushMethodName];
     

--- a/www/CordovaCall.js
+++ b/www/CordovaCall.js
@@ -74,14 +74,6 @@ exports.unmute = function (sessionId, success, error) {
   exec(success, error, "CordovaCall", "unmute", [sessionId]);
 };
 
-exports.hold = function (sessionId, success, error) {
-  exec(success, error, "CordovaCall", "hold", [sessionId]);
-};
-
-exports.unhold = function (sessionId, success, error) {
-  exec(success, error, "CordovaCall", "unhold", [sessionId]);
-};
-
 exports.speakerOn = function (success, error) {
   exec(success, error, "CordovaCall", "speakerOn", []);
 };

--- a/www/CordovaCall.js
+++ b/www/CordovaCall.js
@@ -36,7 +36,7 @@ exports.setVideo = function (value, success, error) {
   }
 };
 
-exports.receiveCall = function (from, id, success, error) {
+exports.receiveCall = function (from, id, sessionId, success, error) {
   if (typeof id == "function") {
     error = success;
     success = id;
@@ -44,7 +44,7 @@ exports.receiveCall = function (from, id, success, error) {
   } else if (id) {
     id = id.toString();
   }
-  exec(success, error, "CordovaCall", "receiveCall", [from, id]);
+  exec(success, error, "CordovaCall", "receiveCall", [from, id, sessionId]);
 };
 
 exports.sendCall = function (to, id, sessionId, success, error) {

--- a/www/CordovaCall.js
+++ b/www/CordovaCall.js
@@ -47,7 +47,7 @@ exports.receiveCall = function (from, id, success, error) {
   exec(success, error, "CordovaCall", "receiveCall", [from, id]);
 };
 
-exports.sendCall = function (to, id, success, error) {
+exports.sendCall = function (to, id, success, error, sessionId) {
   if (typeof id == "function") {
     error = success;
     success = id;
@@ -55,23 +55,31 @@ exports.sendCall = function (to, id, success, error) {
   } else if (id) {
     id = id.toString();
   }
-  exec(success, error, "CordovaCall", "sendCall", [to, id]);
+  exec(success, error, "CordovaCall", "sendCall", [to, id, sessionId]);
 };
 
-exports.connectCall = function (success, error) {
-  exec(success, error, "CordovaCall", "connectCall", []);
+exports.connectCall = function (success, error, sessionId) {
+  exec(success, error, "CordovaCall", "connectCall", [sessionId]);
 };
 
-exports.endCall = function (success, error) {
-  exec(success, error, "CordovaCall", "endCall", []);
+exports.endCall = function (success, error, sessionId) {
+  exec(success, error, "CordovaCall", "endCall", [sessionId]);
 };
 
-exports.mute = function (success, error) {
-  exec(success, error, "CordovaCall", "mute", []);
+exports.mute = function (success, error, sessionId) {
+  exec(success, error, "CordovaCall", "mute", [sessionId]);
 };
 
-exports.unmute = function (success, error) {
-  exec(success, error, "CordovaCall", "unmute", []);
+exports.unmute = function (success, error, sessionId) {
+  exec(success, error, "CordovaCall", "unmute", [sessionId]);
+};
+
+exports.hold = function (success, error, sessionId) {
+  exec(success, error, "CordovaCall", "hold", [sessionId]);
+};
+
+exports.unhold = function (success, error, sessionId) {
+  exec(success, error, "CordovaCall", "unhold", [sessionId]);
 };
 
 exports.speakerOn = function (success, error) {
@@ -107,8 +115,8 @@ exports.openFullScreenIntentSettings = function (success, error) {
   exec(success, error, "CordovaCall", "openFullScreenIntentSettings", []);
 };
 
-exports.dismissRingingCall = function (success) {
-  exec(success, null, "CordovaCall", "dismissRingingCall", []);
+exports.dismissRingingCall = function (success, sessionId) {
+  exec(success, null, "CordovaCall", "dismissRingingCall", [sessionId]);
 }
 
 // iOS Only Functions

--- a/www/CordovaCall.js
+++ b/www/CordovaCall.js
@@ -36,7 +36,7 @@ exports.setVideo = function (value, success, error) {
   }
 };
 
-exports.receiveCall = function (from, id, sessionId, success, error) {
+exports.receiveCall = function (sessionId, from, id, success, error) {
   if (typeof id == "function") {
     error = success;
     success = id;
@@ -47,7 +47,7 @@ exports.receiveCall = function (from, id, sessionId, success, error) {
   exec(success, error, "CordovaCall", "receiveCall", [from, id, sessionId]);
 };
 
-exports.sendCall = function (to, id, sessionId, success, error) {
+exports.sendCall = function (sessionId, to, id, success, error) {
   if (typeof id == "function") {
     error = success;
     success = id;

--- a/www/CordovaCall.js
+++ b/www/CordovaCall.js
@@ -47,7 +47,7 @@ exports.receiveCall = function (from, id, success, error) {
   exec(success, error, "CordovaCall", "receiveCall", [from, id]);
 };
 
-exports.sendCall = function (to, id, success, error, sessionId) {
+exports.sendCall = function (to, id, sessionId, success, error) {
   if (typeof id == "function") {
     error = success;
     success = id;
@@ -58,27 +58,27 @@ exports.sendCall = function (to, id, success, error, sessionId) {
   exec(success, error, "CordovaCall", "sendCall", [to, id, sessionId]);
 };
 
-exports.connectCall = function (success, error, sessionId) {
+exports.connectCall = function (sessionId, success, error) {
   exec(success, error, "CordovaCall", "connectCall", [sessionId]);
 };
 
-exports.endCall = function (success, error, sessionId) {
+exports.endCall = function (sessionId, success, error) {
   exec(success, error, "CordovaCall", "endCall", [sessionId]);
 };
 
-exports.mute = function (success, error, sessionId) {
+exports.mute = function (sessionId, success, error) {
   exec(success, error, "CordovaCall", "mute", [sessionId]);
 };
 
-exports.unmute = function (success, error, sessionId) {
+exports.unmute = function (sessionId, success, error) {
   exec(success, error, "CordovaCall", "unmute", [sessionId]);
 };
 
-exports.hold = function (success, error, sessionId) {
+exports.hold = function (sessionId, success, error) {
   exec(success, error, "CordovaCall", "hold", [sessionId]);
 };
 
-exports.unhold = function (success, error, sessionId) {
+exports.unhold = function (sessionId, success, error) {
   exec(success, error, "CordovaCall", "unhold", [sessionId]);
 };
 
@@ -115,7 +115,7 @@ exports.openFullScreenIntentSettings = function (success, error) {
   exec(success, error, "CordovaCall", "openFullScreenIntentSettings", []);
 };
 
-exports.dismissRingingCall = function (success, sessionId) {
+exports.dismissRingingCall = function (sessionId, success) {
   exec(success, null, "CordovaCall", "dismissRingingCall", [sessionId]);
 }
 


### PR DESCRIPTION
Framework for supporting multiple calls, will work once hold/unhold logic is added.
The following functions now require passing along a `sessionId` to identify which call to action on: `sendCall`, `connectCall`, `endCall`, `mute`, `unmute`, `dismissRingingCall`

TODO: Implement Hold/Unhold in new PR to limit changes and make it easier to test. Multi-call should work when that's implemented.

General Changes:
- Callkit internally keeps track of all calls using `NSUUID` only, it must be a specific format and must be generated
- Needs mapping between facetalk identifier <-> Callkit Identifier
- Internally keeps track of `activeCalls` with mapping details
  - Inbound softphone call: stores `callId` or `call_id;ftag;ttag = call_uuid`
  - Outbound softphone call: stores `sessionId` or `sessionId._request.id`
  - Conference Call: stores `meeting-${ConferenceCallStore.get('id')}`
- Adds an entry when Pushkit Incoming Call or `sendCall`
- Removes an entry when `performEndCallAction` which executes everytime a call ends
- Reorder `CordovaCall` function params to accept `sessionId` before callbacks

Old way: `NSArray<CXCall *> *calls = self.callController.callObserver.calls;` and then `calls[0]`.
- Only ever keeps track of 1 call

New way (Facetalk -> Callkit flow): `CXCall *call = [self callForCallId:callId];`
- `callForCallId` finds the Callkit call associated with the `callId`
- If a matching Call is found then we action on it, not found then it's ignored

New way (Callkit -> Facetalk flow): `NSString *callId = [self callIdForUUID:action.callUUID];`
- `performAnswerCallAction`/`performEndCallAction`/`performSetMutedCallAction` excecutes when Callkit UI is pressed
  - They provide only `action.callUUID`/`NSUUID` for which call was answered/rejected/ended/muted/umuted
  - Keep existing logic to pass through the incoming call payload for `answer` and `reject`
  - Passes through `sessionId` for mute/unmute/hangup call
- `callIdForUUID` finds the `callId` associated with a `NSUUID`