### PR TITLE
Decouple sendCall/receiveCall Actions from checkCallPermissions() + leave Permission Requests to Facetalk

### DIFF
--- a/src/android/CordovaCall.java
+++ b/src/android/CordovaCall.java
@@ -199,13 +199,6 @@ public class CordovaCall extends CordovaPlugin {
                 }
             } else {
                 to = args.getString(0);
-
-                // Client web app should request this permission before hand
-                if (!CordovaCall.getCordova().hasPermission(Manifest.permission.READ_PHONE_NUMBERS)) {
-                    this.callbackContext.error("READ_PHONE_NUMBER_PERMISSION not granted, cant proceed with placing a call");
-                    return true;
-                }
-
                 this.sendCall();
             }
             return true;
@@ -334,6 +327,7 @@ public class CordovaCall extends CordovaPlugin {
     }
 
     private void checkCallPermission() {
+        // Your client web app should have already checked/requested the READ_PHONE_NUMBERS runtime permission before hand.
         if (!CordovaCall.getCordova().hasPermission(Manifest.permission.READ_PHONE_NUMBERS)) {
             this.callbackContext.error(READ_PHONE_NUMBERS_REQUIRED);
             return; // Don't proceed to call TelecomManager.getPhoneAccount() as that would throw an error which in some cases may crash the entire app
@@ -362,6 +356,12 @@ public class CordovaCall extends CordovaPlugin {
     }
 
     private void sendCall() {
+        // Your client web app should have already checked/requested READ_PHONE_NUMBERS before hand
+        if (!CordovaCall.getCordova().hasPermission(Manifest.permission.READ_PHONE_NUMBERS)) {
+            this.callbackContext.error("READ_PHONE_NUMBER_PERMISSION not granted, cant proceed with placing a call");
+            return true; // Important: as attempting do tm.placeCall() without permission crashes the entire app
+        }
+    
         Uri uri = Uri.fromParts("tel", to, null);
         Bundle callInfoBundle = new Bundle();
         callInfoBundle.putString("to",to);

--- a/src/android/CordovaCall.java
+++ b/src/android/CordovaCall.java
@@ -55,6 +55,8 @@ public class CordovaCall extends CordovaPlugin {
     private JSONArray pendingActionArgs;
     private TelecomManager tm;
 
+    private boolean requestCamera;
+
     private CallbackContext callbackContext;
     private String appName;
     private String from;
@@ -202,10 +204,7 @@ public class CordovaCall extends CordovaPlugin {
                 }
             } else {
                 from = args.getString(0);
-                permissionCounter = 2;
-                pendingAction = "receiveCall";
-                pendingActionArgs = args;
-                this.checkCallPermission();
+                this.receiveCall();
             }
             return true;
         } else if (action.equals("sendCall")) {
@@ -220,10 +219,14 @@ public class CordovaCall extends CordovaPlugin {
                 }
             } else {
                 to = args.getString(0);
-                permissionCounter = 2;
-                pendingAction = "sendCall";
-                pendingActionArgs = args;
-                this.checkCallPermission();
+
+                // Client web app should request this permission before hand
+                if (!CordovaCall.getCordova().hasPermission(Manifest.permission.READ_PHONE_NUMBERS)) {
+                    this.callbackContext.error("READ_PHONE_NUMBER_PERMISSION not granted, cant proceed with placing a call");
+                    return true;
+                }
+
+                this.sendCall();
             }
             return true;
         } else if (action.equals("connectCall")) {
@@ -317,6 +320,8 @@ public class CordovaCall extends CordovaPlugin {
             return true;
         } else if (action.equals("checkCallPermission")) {
             permissionCounter = 2;
+            this.pendingAction = "checkCallPermission";
+            this.pendingActionArgs = args;
             this.checkCallPermission();
             return true;
         } else if (action.equals("canUseFullScreenIntent")) {
@@ -355,9 +360,6 @@ public class CordovaCall extends CordovaPlugin {
         if(permissionCounter >= 1) {
             // Check READ_PHONE_NUMBERS permission
             if (!CordovaCall.getCordova().hasPermission(Manifest.permission.READ_PHONE_NUMBERS)) {
-                if (this.pendingAction != null) {
-                    this.callbackContext.error(READ_PHONE_NUMBERS_REQUIRED);
-                }
                 return; // Don't proceed to call TelecomManager.getPhoneAccount() as that would throw an error which in some cases may crash the entire app
             }
 
@@ -367,28 +369,14 @@ public class CordovaCall extends CordovaPlugin {
                 return; // Return here and continue in onRequestPermissionResult
             }
 
-            Boolean requestCamera = false;
-            try {
-                requestCamera = "sendCall".equals(this.pendingAction) && this.pendingActionArgs.getString(1).startsWith("meeting");
-            } catch (JSONException e) {
-                // Because pendingActionArgs is a JSON array we must either declare this function throws JSONExceptions or suround with try/catch
-                throw new RuntimeException(e);
-            }
-
-            if (requestCamera && !CordovaCall.getCordova().hasPermission(Manifest.permission.CAMERA)) {
+            if (this.requestCamera && !CordovaCall.getCordova().hasPermission(Manifest.permission.CAMERA)) {
                 cordova.requestPermission(this, CAMERA_REQ_CODE, Manifest.permission.CAMERA);
                 return; // Return here and continue in onRequestPermissionResult
             }
 
             PhoneAccountHandle handle = PhoneAccountManager.getPhoneAccountHandle(this.cordova.getActivity().getApplicationContext());
             PhoneAccount currentPhoneAccount = tm.getPhoneAccount(handle); // Requires android.permissions.READ_PHONE_NUMBERS
-            if(currentPhoneAccount.isEnabled()) {
-                if(pendingAction == "receiveCall") {
-                    this.receiveCall();
-                } else if(pendingAction == "sendCall") {
-                    this.sendCall();
-                }
-            } else {
+            if(currentPhoneAccount.isEnabled() == false) {
                 if(permissionCounter == 2) {
                     Intent phoneIntent = new Intent(TelecomManager.ACTION_CHANGE_PHONE_ACCOUNTS);
                     phoneIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_SINGLE_TOP);

--- a/src/android/CordovaCall.java
+++ b/src/android/CordovaCall.java
@@ -1,7 +1,5 @@
 package com.dmarc.cordovacall;
 
-import static android.provider.Settings.ACTION_MANAGE_APP_USE_FULL_SCREEN_INTENT;
-
 import org.apache.cordova.CordovaPlugin;
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaInterface;
@@ -9,7 +7,6 @@ import org.apache.cordova.CordovaWebView;
 import org.apache.cordova.PluginResult;
 
 import android.app.Activity;
-import android.app.Application;
 import android.app.NotificationManager;
 import android.content.ActivityNotFoundException;
 import android.os.Build;
@@ -35,27 +32,13 @@ import android.util.Log;
 import android.view.WindowManager;
 import android.widget.Toast;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.core.app.NotificationCompat;
-
 public class CordovaCall extends CordovaPlugin {
     private static String READ_PHONE_NUMBERS_REQUIRED = "read_phone_numbers_permission_required";
-    private static String RECORD_AUDIO_REQUIRED = "record_audio_permission_required";
-    private static String CAMERA_PERMISSION_REQUIRED = "camera_permission_required";
 
     private static String TAG = "CordovaCall";
-    public static final int CALL_PHONE_REQ_CODE = 0;
     public static final int REAL_PHONE_CALL = 1;
-    public static final int RECORD_AUDIO_REQ_CODE = 2;
-    public static final int CAMERA_REQ_CODE = 3;
 
-    private int permissionCounter = 0;
-    private String pendingAction;
-    private JSONArray pendingActionArgs;
     private TelecomManager tm;
-
-    private boolean requestCamera;
 
     private CallbackContext callbackContext;
     private String appName;
@@ -178,9 +161,6 @@ public class CordovaCall extends CordovaPlugin {
     @Override
     public void onResume(boolean multitasking) {
         super.onResume(multitasking);
-        if (this.pendingAction != null) {
-            this.checkCallPermission();
-        }
         setMainActivityInForeground(true);
     }
 
@@ -319,9 +299,6 @@ public class CordovaCall extends CordovaPlugin {
             }
             return true;
         } else if (action.equals("checkCallPermission")) {
-            permissionCounter = 2;
-            this.pendingAction = "checkCallPermission";
-            this.pendingActionArgs = args;
             this.checkCallPermission();
             return true;
         } else if (action.equals("canUseFullScreenIntent")) {
@@ -357,36 +334,18 @@ public class CordovaCall extends CordovaPlugin {
     }
 
     private void checkCallPermission() {
-        if(permissionCounter >= 1) {
-            // Check READ_PHONE_NUMBERS permission
-            if (!CordovaCall.getCordova().hasPermission(Manifest.permission.READ_PHONE_NUMBERS)) {
-                return; // Don't proceed to call TelecomManager.getPhoneAccount() as that would throw an error which in some cases may crash the entire app
-            }
-
-            // Check RECORD_AUDIO permission for microphone access
-            if (!CordovaCall.getCordova().hasPermission(Manifest.permission.RECORD_AUDIO)) {
-                cordova.requestPermission(this, RECORD_AUDIO_REQ_CODE, Manifest.permission.RECORD_AUDIO);
-                return; // Return here and continue in onRequestPermissionResult
-            }
-
-            if (this.requestCamera && !CordovaCall.getCordova().hasPermission(Manifest.permission.CAMERA)) {
-                cordova.requestPermission(this, CAMERA_REQ_CODE, Manifest.permission.CAMERA);
-                return; // Return here and continue in onRequestPermissionResult
-            }
-
-            PhoneAccountHandle handle = PhoneAccountManager.getPhoneAccountHandle(this.cordova.getActivity().getApplicationContext());
-            PhoneAccount currentPhoneAccount = tm.getPhoneAccount(handle); // Requires android.permissions.READ_PHONE_NUMBERS
-            if(currentPhoneAccount.isEnabled() == false) {
-                if(permissionCounter == 2) {
-                    Intent phoneIntent = new Intent(TelecomManager.ACTION_CHANGE_PHONE_ACCOUNTS);
-                    phoneIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_SINGLE_TOP);
-                    this.cordova.getActivity().getApplicationContext().startActivity(phoneIntent);
-                } else {
-                    this.callbackContext.error(READ_PHONE_NUMBERS_REQUIRED);
-                }
-            }
+        if (!CordovaCall.getCordova().hasPermission(Manifest.permission.READ_PHONE_NUMBERS)) {
+            this.callbackContext.error(READ_PHONE_NUMBERS_REQUIRED);
+            return; // Don't proceed to call TelecomManager.getPhoneAccount() as that would throw an error which in some cases may crash the entire app
         }
-        permissionCounter--;
+
+        PhoneAccountHandle handle = PhoneAccountManager.getPhoneAccountHandle(this.cordova.getActivity().getApplicationContext());
+        PhoneAccount currentPhoneAccount = tm.getPhoneAccount(handle); // Requires android.permissions.READ_PHONE_NUMBERS
+        if(!currentPhoneAccount.isEnabled()) {
+            Intent phoneIntent = new Intent(TelecomManager.ACTION_CHANGE_PHONE_ACCOUNTS);
+            phoneIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+            this.cordova.getActivity().getApplicationContext().startActivity(phoneIntent);
+        }
     }
 
     private void receiveCall() {
@@ -396,7 +355,6 @@ public class CordovaCall extends CordovaPlugin {
         PhoneAccountHandle handle = PhoneAccountManager.getPhoneAccountHandle(this.cordova.getActivity().getApplicationContext());
         tm.addNewIncomingCall(handle, callInfo);
 
-        permissionCounter = 0;
         this.callbackContext.success("Incoming call successful");
 
         this.bringAppToFront();
@@ -414,14 +372,20 @@ public class CordovaCall extends CordovaPlugin {
         callInfo.putParcelable(TelecomManager.EXTRA_PHONE_ACCOUNT_HANDLE, handle);
 
         callInfo.putBoolean(TelecomManager.EXTRA_START_CALL_WITH_VIDEO_STATE, true);
-        tm.placeCall(uri, callInfo);
-        permissionCounter = 0;
+
+        if (!CordovaCall.getCordova().hasPermission(Manifest.permission.MANAGE_OWN_CALLS)) {
+            // This should in theory never happen - assuming no one removes MANAGE_OWN_CALLS from the android manifest
+            this.callbackContext.error("MANAGE_OWN_CALLS permission not declared - required in order to use TelecomManager.placeCall()");
+            return;
+        }
+
+        tm.placeCall(uri, callInfo); // Triggers sometime later, an onCreateOutgoingConnection callback to your ConnectionService
+
         this.callbackContext.success("Outgoing call successful");
     }
 
     private void bringAppToFront() {
         Intent intent = new Intent(this.cordova.getActivity().getApplicationContext(), this.cordova.getActivity().getClass());
-        // Intent.FLAG_ACTIVITY_REORDER_TO_FRONT Intent.FLAG_ACTIVITY_BROUGHT_TO_FRONT
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_BROUGHT_TO_FRONT | Intent.FLAG_FROM_BACKGROUND);
         this.cordova.getActivity().getApplicationContext().startActivity(intent);
     }
@@ -481,10 +445,6 @@ public class CordovaCall extends CordovaPlugin {
         }
     }
 
-    protected void getCallPhonePermission() {
-        cordova.requestPermission(this, CALL_PHONE_REQ_CODE, Manifest.permission.CALL_PHONE);
-    }
-
     protected void callNumberPhonePermission() {
         cordova.requestPermission(this, REAL_PHONE_CALL, Manifest.permission.CALL_PHONE);
     }
@@ -506,35 +466,15 @@ public class CordovaCall extends CordovaPlugin {
         {
             if(r == PackageManager.PERMISSION_DENIED)
             {
-                if(requestCode == RECORD_AUDIO_REQ_CODE) {
-                    this.callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.ERROR, RECORD_AUDIO_REQUIRED));
-                } else if (requestCode == CAMERA_REQ_CODE) {
-                    this.callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.ERROR, CAMERA_PERMISSION_REQUIRED));
-                } else {
-                    this.callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.ERROR, "CALL_PHONE Permission Denied"));
-                }
+                this.callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.ERROR, "CALL_PHONE Permission Denied"));
                 return;
             }
         }
         switch(requestCode)
         {
-            case CALL_PHONE_REQ_CODE:
-                this.sendCall();
-                break;
             case REAL_PHONE_CALL:
                 this.callNumber();
                 break;
-            case RECORD_AUDIO_REQ_CODE:
-            case CAMERA_REQ_CODE:
-                // Permission granted, continue with the call process
-                this.checkCallPermission();
-                break;
         }
-    }
-
-    public void requestPermissions() {
-        Intent phoneIntent = new Intent(TelecomManager.ACTION_CHANGE_PHONE_ACCOUNTS);
-        phoneIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_SINGLE_TOP);
-        this.cordova.getActivity().getApplicationContext().startActivity(phoneIntent);
     }
 }

--- a/src/android/CordovaCall.java
+++ b/src/android/CordovaCall.java
@@ -359,7 +359,7 @@ public class CordovaCall extends CordovaPlugin {
         // Your client web app should have already checked/requested READ_PHONE_NUMBERS before hand
         if (!CordovaCall.getCordova().hasPermission(Manifest.permission.READ_PHONE_NUMBERS)) {
             this.callbackContext.error("READ_PHONE_NUMBER_PERMISSION not granted, cant proceed with placing a call");
-            return true; // Important: as attempting do tm.placeCall() without permission crashes the entire app
+            return; // Important: as attempting do tm.placeCall() without permission crashes the entire app
         }
     
         Uri uri = Uri.fromParts("tel", to, null);

--- a/src/android/CordovaCall.java
+++ b/src/android/CordovaCall.java
@@ -362,12 +362,6 @@ public class CordovaCall extends CordovaPlugin {
             return; // Important: as attempting do tm.placeCall() without permission crashes the entire app
         }
 
-        if (!CordovaCall.getCordova().hasPermission(Manifest.permission.MANAGE_OWN_CALLS)) {
-            // This should in theory never happen - assuming no one removes MANAGE_OWN_CALLS from the android manifest
-            this.callbackContext.error("MANAGE_OWN_CALLS permission not declared - required in order to use TelecomManager.placeCall()");
-            return;
-        }
-
         Uri uri = Uri.fromParts("tel", to, null);
         Bundle callInfoBundle = new Bundle();
         callInfoBundle.putString("to",to);
@@ -384,7 +378,13 @@ public class CordovaCall extends CordovaPlugin {
             this.callbackContext.error("no_phone_account_enabled");
             return;
         }
-        
+
+        if (!CordovaCall.getCordova().hasPermission(Manifest.permission.MANAGE_OWN_CALLS)) {
+            // This should in theory never happen - assuming no one removes MANAGE_OWN_CALLS from the android manifest
+            this.callbackContext.error("MANAGE_OWN_CALLS permission not declared - required in order to use TelecomManager.placeCall()");
+            return;
+        }
+
         tm.placeCall(uri, callInfo); // Triggers sometime later, an onCreateOutgoingConnection callback to your ConnectionService
 
         this.callbackContext.success("Outgoing call successful");

--- a/src/android/CordovaCall.java
+++ b/src/android/CordovaCall.java
@@ -361,7 +361,13 @@ public class CordovaCall extends CordovaPlugin {
             this.callbackContext.error("READ_PHONE_NUMBER_PERMISSION not granted, cant proceed with placing a call");
             return; // Important: as attempting do tm.placeCall() without permission crashes the entire app
         }
-    
+
+        if (!CordovaCall.getCordova().hasPermission(Manifest.permission.MANAGE_OWN_CALLS)) {
+            // This should in theory never happen - assuming no one removes MANAGE_OWN_CALLS from the android manifest
+            this.callbackContext.error("MANAGE_OWN_CALLS permission not declared - required in order to use TelecomManager.placeCall()");
+            return;
+        }
+
         Uri uri = Uri.fromParts("tel", to, null);
         Bundle callInfoBundle = new Bundle();
         callInfoBundle.putString("to",to);
@@ -373,12 +379,12 @@ public class CordovaCall extends CordovaPlugin {
 
         callInfo.putBoolean(TelecomManager.EXTRA_START_CALL_WITH_VIDEO_STATE, true);
 
-        if (!CordovaCall.getCordova().hasPermission(Manifest.permission.MANAGE_OWN_CALLS)) {
-            // This should in theory never happen - assuming no one removes MANAGE_OWN_CALLS from the android manifest
-            this.callbackContext.error("MANAGE_OWN_CALLS permission not declared - required in order to use TelecomManager.placeCall()");
+        PhoneAccount currentPhoneAccount = tm.getPhoneAccount(handle); // Requires android.permissions.READ_PHONE_NUMBERS
+        if (currentPhoneAccount == null || !currentPhoneAccount.isEnabled()) {
+            this.callbackContext.error("no_phone_account_enabled");
             return;
         }
-
+        
         tm.placeCall(uri, callInfo); // Triggers sometime later, an onCreateOutgoingConnection callback to your ConnectionService
 
         this.callbackContext.success("Outgoing call successful");

--- a/src/android/CordovaCall.java
+++ b/src/android/CordovaCall.java
@@ -335,7 +335,7 @@ public class CordovaCall extends CordovaPlugin {
 
         PhoneAccountHandle handle = PhoneAccountManager.getPhoneAccountHandle(this.cordova.getActivity().getApplicationContext());
         PhoneAccount currentPhoneAccount = tm.getPhoneAccount(handle); // Requires android.permissions.READ_PHONE_NUMBERS
-        if(!currentPhoneAccount.isEnabled()) {
+        if (currentPhoneAccount == null || !currentPhoneAccount.isEnabled()) {
             Intent phoneIntent = new Intent(TelecomManager.ACTION_CHANGE_PHONE_ACCOUNTS);
             phoneIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_SINGLE_TOP);
             this.cordova.getActivity().getApplicationContext().startActivity(phoneIntent);


### PR DESCRIPTION
**Greatly simplifies** the code/operation of sendCall() and receiveCall() (unused for now).

This will put the responsiblity of checking/requesting:
- READ_PHONE_NUMBERS
- MIC Permission
- Camera permission

on facetalk. Facetalk will have a PR to check these things accordingly before calling sendCall.

- checkCallPermission() now simply does the phone account check (opens settings page to allow user to choose which phone account to enable if none enabled - a requirement in some cases to proceed with placing calls)



TO COME:  facetalk PR to accompany this