### PR TITLE
[Android] Critical: Multiple Call Support  + Basic Hold/Unhold Support

### DIFF
--- a/src/android/AudioRouteMonitor.java
+++ b/src/android/AudioRouteMonitor.java
@@ -33,7 +33,6 @@ public class AudioRouteMonitor {
     private final AudioManager audioManager;
     private BroadcastReceiver audioRouteReceiver;
 
-    private static int activeCallCount = 0;
     private static AudioRouteMonitor instance;
 
     public AudioRouteMonitor(CordovaInterface cordova, AudioManager audioManager) {
@@ -54,9 +53,9 @@ public class AudioRouteMonitor {
      * Starts monitoring on the first active call.
      */
     public static void onCallConnected() {
-        activeCallCount++;
-        Log.d(TAG, "Active call count incremented to: " + activeCallCount);
-        if (activeCallCount == 1 && instance != null) {
+        int count = MyConnectionService.getActiveCallCount();
+        Log.d(TAG, "onCallConnected, active call count: " + count);
+        if (count == 1 && instance != null) {
             instance.startMonitoring();
         }
     }
@@ -66,14 +65,10 @@ public class AudioRouteMonitor {
      * Stops monitoring when the last active call ends.
      */
     public static void onCallEnded() {
-        if (activeCallCount > 0) {
-            activeCallCount--;
-            Log.d(TAG, "Active call count decremented to: " + activeCallCount);
-            if (activeCallCount == 0 && instance != null) {
-                instance.stopMonitoring();
-            }
-        } else {
-            Log.w(TAG, "Attempted to decrement active call count when already 0");
+        int count = MyConnectionService.getActiveCallCount();
+        Log.d(TAG, "onCallEnded, active call count: " + count);
+        if (count == 0 && instance != null) {
+            instance.stopMonitoring();
         }
     }
 

--- a/src/android/CallActionReceiver.java
+++ b/src/android/CallActionReceiver.java
@@ -14,12 +14,14 @@ public class CallActionReceiver extends BroadcastReceiver {
         String action = intent.getAction();
         Log.d(TAG, "onReceive, intent action: " + action);
 
+        String sessionId = intent.getStringExtra("sessionId");
+        Connection conn = MyConnectionService.getConnection(sessionId);
+
         if (action.equals("hangUpCall")) {
-            Connection activeConnection = MyConnectionService.getConnection();
-            if (activeConnection != null) {
-                activeConnection.onDisconnect();
+            if (conn != null) {
+                conn.onDisconnect();
             } else {
-                Log.d(TAG, "no active call to disconnect (possibly already disconnected), closing notification");
+                Log.d(TAG, "no call to disconnect (possibly already disconnected), closing notification");
                 // Normally: we disconnect the telecom connection, which brings down the CallAudioService foreground service and its notification in turn
                 // For robustness (to prevent any orphaned ongoing notification) ensure the foreground service + notification is shutdown
                 Intent serviceIntent = new Intent(context, CallAudioService.class);
@@ -27,10 +29,6 @@ public class CallActionReceiver extends BroadcastReceiver {
             }
             return;
         }
-
-        String pushMessagePayload = intent.getStringExtra("pushMessagePayload");
-
-        Connection conn = MyConnectionService.getConnectionByPayload(pushMessagePayload);
 
         if (conn != null) {
             if (action.equals("declineCall")) {
@@ -41,7 +39,7 @@ public class CallActionReceiver extends BroadcastReceiver {
                 throw new RuntimeException("Invalid action: " + action);
             }
         } else {
-            Log.d(TAG, "Exiting, connection no longer exists. pushMessagePayload: " + pushMessagePayload);
+            Log.d(TAG, "Exiting, connection no longer exists. sessionId: " + sessionId);
         }
     }
 }

--- a/src/android/CallActionReceiver.java
+++ b/src/android/CallActionReceiver.java
@@ -1,6 +1,5 @@
 package com.dmarc.cordovacall;
 
-import android.app.NotificationManager;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;

--- a/src/android/CallAudioService.java
+++ b/src/android/CallAudioService.java
@@ -33,8 +33,9 @@ public class CallAudioService extends Service {
         }
 
         String peerName = intent.getStringExtra("peerName");
+        String sessionId = intent.getStringExtra("sessionId");
 
-        OngoingCallNotification onGoingCallNotification = new OngoingCallNotification(this.getApplicationContext(), peerName);
+        OngoingCallNotification onGoingCallNotification = new OngoingCallNotification(this.getApplicationContext(), peerName, sessionId);
 
         Notification notification = onGoingCallNotification.build();
         int notificationID = onGoingCallNotification.getNotificationID();

--- a/src/android/CallConnection.java
+++ b/src/android/CallConnection.java
@@ -52,8 +52,11 @@ class CallConnection extends Connection {
             Log.d(MyConnectionService.TAG, "Starting CallAudioService...");
             Intent intent = new Intent(service.getApplicationContext(), CallAudioService.class);
             intent.putExtra("peerName", peerName);
+            intent.putExtra("sessionId", this.sessionId);
             service.startForegroundService(intent);
         } else if (state == Connection.STATE_ACTIVE) {
+            service.setActiveSessionId(this.sessionId);
+
             AudioRouteMonitor.onCallConnected();
         } else if (state == Connection.STATE_DISCONNECTED) {
             this.destroy();

--- a/src/android/CallConnection.java
+++ b/src/android/CallConnection.java
@@ -15,9 +15,11 @@ import android.util.Log;
  */
 class CallConnection extends Connection {
     protected final MyConnectionService service;
+    protected String peerName;
 
-    CallConnection(MyConnectionService service) {
+    CallConnection(MyConnectionService service, String peerName) {
         this.service = service;
+        this.peerName = peerName;
     }
 
     @Override
@@ -40,15 +42,27 @@ class CallConnection extends Connection {
     @Override
     public void onStateChanged(int state) {
         super.onStateChanged(state);
-        if (state == Connection.STATE_ACTIVE) {
+        Log.d(MyConnectionService.TAG, "connection onStateChanged new state: " + Connection.stateToString(state));
+
+        if (state == Connection.STATE_RINGING || state == Connection.STATE_DIALING) {
+            // NOTE: CallAudioService should be started before mic access, in order to work.
+            // IMPORTANT: This preserves the ability to use the mic when the app is in the background!
+            Log.d(MyConnectionService.TAG, "Starting CallAudioService...");
+            Intent intent = new Intent(service.getApplicationContext(), CallAudioService.class);
+            intent.putExtra("peerName", peerName);
+            service.startForegroundService(intent);
+        } else if (state == Connection.STATE_ACTIVE) {
             AudioRouteMonitor.onCallConnected();
         } else if (state == Connection.STATE_DISCONNECTED) {
             this.destroy();
             AudioRouteMonitor.onCallEnded();
+
             Log.d(MyConnectionService.TAG, "Stopping CallAudioService...");
             Context context = service.getApplicationContext();
             Intent serviceIntent = new Intent(context, CallAudioService.class);
             context.stopService(serviceIntent);
+
+            MyConnectionService.activeConnectionUUID = null;
         }
     }
 }

--- a/src/android/CallConnection.java
+++ b/src/android/CallConnection.java
@@ -54,8 +54,6 @@ class CallConnection extends Connection {
             intent.putExtra("peerName", peerName);
             service.startForegroundService(intent);
         } else if (state == Connection.STATE_ACTIVE) {
-            service.setActiveSessionId(this.sessionId);
-
             AudioRouteMonitor.onCallConnected();
         } else if (state == Connection.STATE_DISCONNECTED) {
             this.destroy();

--- a/src/android/CallConnection.java
+++ b/src/android/CallConnection.java
@@ -59,10 +59,13 @@ class CallConnection extends Connection {
             this.destroy();
             AudioRouteMonitor.onCallEnded();
 
-            Log.d(MyConnectionService.TAG, "Stopping CallAudioService...");
-            Context context = service.getApplicationContext();
-            Intent serviceIntent = new Intent(context, CallAudioService.class);
-            context.stopService(serviceIntent);
+            // Only stop CallAudioService when there are no remaining active calls.
+            if (AudioRouteMonitor.activeCallCount <= 0) {
+                Log.d(MyConnectionService.TAG, "Stopping CallAudioService...");
+                Context context = service.getApplicationContext();
+                Intent serviceIntent = new Intent(context, CallAudioService.class);
+                context.stopService(serviceIntent);
+            }
 
             MyConnectionService.onConnectionDisconnected(this.sessionId);
         }

--- a/src/android/CallConnection.java
+++ b/src/android/CallConnection.java
@@ -31,6 +31,16 @@ class CallConnection extends Connection {
     }
 
     @Override
+    public void onHold() {
+        this.setOnHold();
+    }
+
+    @Override
+    public void onUnhold() {
+        this.setActive();
+    }
+
+    @Override
     public void onAbort() {
         this.setDisconnected(new DisconnectCause(DisconnectCause.CANCELED));
     }

--- a/src/android/CallConnection.java
+++ b/src/android/CallConnection.java
@@ -54,6 +54,8 @@ class CallConnection extends Connection {
             intent.putExtra("peerName", peerName);
             service.startForegroundService(intent);
         } else if (state == Connection.STATE_ACTIVE) {
+            service.setActiveSessionId(this.sessionId);
+
             AudioRouteMonitor.onCallConnected();
         } else if (state == Connection.STATE_DISCONNECTED) {
             this.destroy();

--- a/src/android/CallConnection.java
+++ b/src/android/CallConnection.java
@@ -31,16 +31,6 @@ class CallConnection extends Connection {
     }
 
     @Override
-    public void onHold() {
-        this.setOnHold();
-    }
-
-    @Override
-    public void onUnhold() {
-        this.setActive();
-    }
-
-    @Override
     public void onAbort() {
         this.setDisconnected(new DisconnectCause(DisconnectCause.CANCELED));
     }
@@ -69,13 +59,10 @@ class CallConnection extends Connection {
             this.destroy();
             AudioRouteMonitor.onCallEnded();
 
-            // Only stop CallAudioService when there are no remaining active calls.
-            if (AudioRouteMonitor.activeCallCount <= 0) {
-                Log.d(MyConnectionService.TAG, "Stopping CallAudioService...");
-                Context context = service.getApplicationContext();
-                Intent serviceIntent = new Intent(context, CallAudioService.class);
-                context.stopService(serviceIntent);
-            }
+            Log.d(MyConnectionService.TAG, "Stopping CallAudioService...");
+            Context context = service.getApplicationContext();
+            Intent serviceIntent = new Intent(context, CallAudioService.class);
+            context.stopService(serviceIntent);
 
             MyConnectionService.onConnectionDisconnected(this.sessionId);
         }

--- a/src/android/CallConnection.java
+++ b/src/android/CallConnection.java
@@ -16,10 +16,12 @@ import android.util.Log;
 class CallConnection extends Connection {
     protected final MyConnectionService service;
     protected String peerName;
+    protected String sessionId;
 
-    CallConnection(MyConnectionService service, String peerName) {
+    CallConnection(MyConnectionService service, String peerName, String sessionId) {
         this.service = service;
         this.peerName = peerName;
+        this.sessionId = sessionId;
     }
 
     @Override
@@ -62,7 +64,7 @@ class CallConnection extends Connection {
             Intent serviceIntent = new Intent(context, CallAudioService.class);
             context.stopService(serviceIntent);
 
-            MyConnectionService.activeConnectionUUID = null;
+            MyConnectionService.onConnectionDisconnected(this.sessionId);
         }
     }
 }

--- a/src/android/CallConnection.java
+++ b/src/android/CallConnection.java
@@ -55,8 +55,6 @@ class CallConnection extends Connection {
             intent.putExtra("sessionId", this.sessionId);
             service.startForegroundService(intent);
         } else if (state == Connection.STATE_ACTIVE) {
-            service.setActiveSessionId(this.sessionId);
-
             AudioRouteMonitor.onCallConnected();
         } else if (state == Connection.STATE_DISCONNECTED) {
             this.destroy();

--- a/src/android/CordovaCall.java
+++ b/src/android/CordovaCall.java
@@ -238,6 +238,25 @@ public class CordovaCall extends CordovaPlugin {
 
             this.callbackContext.success("Call connected successfully");
             return true;
+        } else if (action.equals("hold")) {
+            String sessionId = args.getString(0);
+            Connection conn = MyConnectionService.getConnection(sessionId);
+            if (conn != null) {
+                conn.onHold();
+                this.callbackContext.success("Call put on hold");
+            } else {
+                this.callbackContext.error("No call found for session Id");
+            }
+        } else if (action.equals("unhold")) {
+            String sessionId = args.getString(0);
+            Connection conn = MyConnectionService.getConnection(sessionId);
+            if (conn != null) {
+                conn.onUnhold();
+                this.callbackContext.success("Call un-held");
+            } else {
+                 this.callbackContext.error("No call found for session Id");
+            }
+            return true;
         } else if (action.equals("endCall")) {
             String sessionId = args.getString(0);
             Connection conn = MyConnectionService.getConnection(sessionId);

--- a/src/android/CordovaCall.java
+++ b/src/android/CordovaCall.java
@@ -233,9 +233,8 @@ public class CordovaCall extends CordovaPlugin {
                 this.callbackContext.error("Your call is already connected");
             } else {
                 conn.setActive();
-            }
-
-            this.callbackContext.success("Call connected successfully");
+                this.callbackContext.success("Call connected successfully");
+            }            
             return true;
         } else if (action.equals("hold")) {
             String sessionId = args.getString(0);

--- a/src/android/CordovaCall.java
+++ b/src/android/CordovaCall.java
@@ -241,7 +241,7 @@ public class CordovaCall extends CordovaPlugin {
             Log.d(TAG, "sessionId: " + sessionId);
             Connection conn = MyConnectionService.getConnection(sessionId);
             if (conn != null) {
-                conn.onHold();
+                conn.setOnHold();
                 this.callbackContext.success("Call put on hold");
             } else {
                 Log.e(TAG, "Can not hold - no connection found for session ID");
@@ -252,7 +252,7 @@ public class CordovaCall extends CordovaPlugin {
             String sessionId = args.getString(0);
             Connection conn = MyConnectionService.getConnection(sessionId);
             if (conn != null) {
-                conn.onUnhold();
+                conn.setActive();
                 this.callbackContext.success("Call un-held");
             } else {
                 Log.e(TAG, "Can not unhold - no connection found for session ID");

--- a/src/android/CordovaCall.java
+++ b/src/android/CordovaCall.java
@@ -247,6 +247,7 @@ public class CordovaCall extends CordovaPlugin {
             } else {
                 this.callbackContext.error("No call found for session Id");
             }
+            return true;
         } else if (action.equals("unhold")) {
             String sessionId = args.getString(0);
             Connection conn = MyConnectionService.getConnection(sessionId);

--- a/src/android/CordovaCall.java
+++ b/src/android/CordovaCall.java
@@ -225,7 +225,6 @@ public class CordovaCall extends CordovaPlugin {
             }
             return true;
         } else if (action.equals("connectCall")) {
-            Log.d(TAG, "connectCall");
             String sessionId = args.getString(0);
             Connection conn = MyConnectionService.getConnection(sessionId);
             if (conn == null) {

--- a/src/android/CordovaCall.java
+++ b/src/android/CordovaCall.java
@@ -59,7 +59,6 @@ public class CordovaCall extends CordovaPlugin {
     private CallbackContext callbackContext;
     private String appName;
     private String from;
-    private String to;
     private String realCallTo;
     private static HashMap<String, ArrayList<CallbackContext>> callbackContextMap = new HashMap<String, ArrayList<CallbackContext>>();
     static {
@@ -220,32 +219,33 @@ public class CordovaCall extends CordovaPlugin {
                     this.callbackContext.error("You can't make a call right now");
                 }
             } else {
-                to = args.getString(0);
-                this.sendCall();
+                String to = args.getString(0);
+                String sessionId = args.getString(2);
+                this.sendCall(to, sessionId);
             }
             return true;
         } else if (action.equals("connectCall")) {
-            Connection conn = MyConnectionService.getConnection();
-            if(conn == null) {
+            Log.d(TAG, "connectCall");
+            String sessionId = args.getString(0);
+            Connection conn = MyConnectionService.getConnection(sessionId);
+            if (conn == null) {
                 this.callbackContext.error("No call exists for you to connect");
-            } else if(conn.getState() == Connection.STATE_ACTIVE) {
+            } else if (conn.getState() == Connection.STATE_ACTIVE) {
                 this.callbackContext.error("Your call is already connected");
             } else {
                 conn.setActive();
-                AudioRouteMonitor.onCallConnected(); // Start monitoring if this is the first call
-                Intent intent = new Intent(this.cordova.getActivity().getApplicationContext(), this.cordova.getActivity().getClass());
-                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK|Intent.FLAG_ACTIVITY_SINGLE_TOP);
-                this.cordova.getActivity().getApplicationContext().startActivity(intent);
-                this.callbackContext.success("Call connected successfully");
             }
+
+            this.callbackContext.success("Call connected successfully");
             return true;
         } else if (action.equals("endCall")) {
-            Connection conn = MyConnectionService.getConnection();
+            String sessionId = args.getString(0);
+            Connection conn = MyConnectionService.getConnection(sessionId);
             if(conn == null) {
-                this.callbackContext.error("No call exists for you to end");
+                this.callbackContext.error("No call with this sessionId exists for you to end");
             } else {
-                MyConnectionService.endActiveCall();
-                AudioRouteMonitor.onCallEnded(); // Stop monitoring if this is the last call
+                conn.onDisconnect();
+
                 ArrayList<CallbackContext> callbackContexts = CordovaCall.getCallbackContexts().get("hangup");
                 for (final CallbackContext cbContext : callbackContexts) {
                     cordova.getThreadPool().execute(new Runnable() {
@@ -382,7 +382,7 @@ public class CordovaCall extends CordovaPlugin {
         this.tm.showInCallScreen(false);
     }
 
-    private void sendCall() {
+    private void sendCall(String to, String sessionId) {
         // Your client web app should have already checked/requested READ_PHONE_NUMBERS before hand
         if (!CordovaCall.getCordova().hasPermission(Manifest.permission.READ_PHONE_NUMBERS)) {
             this.callbackContext.error("READ_PHONE_NUMBER_PERMISSION not granted, cant proceed with placing a call");
@@ -391,7 +391,8 @@ public class CordovaCall extends CordovaPlugin {
 
         Uri uri = Uri.fromParts("tel", to, null);
         Bundle callInfoBundle = new Bundle();
-        callInfoBundle.putString("to",to);
+        callInfoBundle.putString("to", to);
+        callInfoBundle.putString("sessionId", sessionId);
         Bundle callInfo = new Bundle();
         callInfo.putParcelable(TelecomManager.EXTRA_OUTGOING_CALL_EXTRAS,callInfoBundle);
 

--- a/src/android/CordovaCall.java
+++ b/src/android/CordovaCall.java
@@ -240,12 +240,14 @@ public class CordovaCall extends CordovaPlugin {
             return true;
         } else if (action.equals("hold")) {
             String sessionId = args.getString(0);
+            Log.d(TAG, "sessionId: " + sessionId);
             Connection conn = MyConnectionService.getConnection(sessionId);
             if (conn != null) {
                 conn.onHold();
                 this.callbackContext.success("Call put on hold");
             } else {
-                this.callbackContext.error("No call found for session Id");
+                Log.e(TAG, "Can not hold - no connection found for session ID");
+                this.callbackContext.error("No call found for session ID");
             }
             return true;
         } else if (action.equals("unhold")) {
@@ -255,7 +257,8 @@ public class CordovaCall extends CordovaPlugin {
                 conn.onUnhold();
                 this.callbackContext.success("Call un-held");
             } else {
-                 this.callbackContext.error("No call found for session Id");
+                Log.e(TAG, "Can not unhold - no connection found for session ID");
+                this.callbackContext.error("No call found for session Id");
             }
             return true;
         } else if (action.equals("endCall")) {

--- a/src/android/IncomingCallConnection.java
+++ b/src/android/IncomingCallConnection.java
@@ -17,8 +17,8 @@ class IncomingCallConnection extends CallConnection {
     private final String payloadString;
     private IncomingCallNotification incomingCallNotification;
 
-    IncomingCallConnection(MyConnectionService service, String callUUID, String payloadString, String callerName) {
-        super(service, callerName);
+    IncomingCallConnection(MyConnectionService service, String callUUID, String payloadString, String callerName, String sessionId) {
+        super(service, callerName, sessionId);
         this.callUUID = callUUID;
         this.payloadString = payloadString;
     }
@@ -81,13 +81,7 @@ class IncomingCallConnection extends CallConnection {
 
     @Override
     public void onStateChanged(int state) {
-        if (state == Connection.STATE_ACTIVE) {
-            MyConnectionService.activeConnectionUUID = callUUID;
-        } else  if (state == Connection.STATE_DISCONNECTED) {
-            MyConnectionService.connectionMap.remove(callUUID);
-            if (MyConnectionService.activeConnectionUUID != null && MyConnectionService.activeConnectionUUID.equals(callUUID)) {
-                MyConnectionService.activeConnectionUUID = null;
-            }
+        if (state == Connection.STATE_DISCONNECTED) {
             cancelIncomingCallNotification();
         }
 

--- a/src/android/IncomingCallConnection.java
+++ b/src/android/IncomingCallConnection.java
@@ -88,9 +88,6 @@ class IncomingCallConnection extends CallConnection {
             if (MyConnectionService.activeConnectionUUID != null && MyConnectionService.activeConnectionUUID.equals(callUUID)) {
                 MyConnectionService.activeConnectionUUID = null;
             }
-            if (this.mainActivityChangeListener != null) {
-                CordovaCall.unregisterMainActivityStateChangeListener(this.mainActivityChangeListener);
-            }
             cancelIncomingCallNotification();
         }
 

--- a/src/android/IncomingCallConnection.java
+++ b/src/android/IncomingCallConnection.java
@@ -15,15 +15,12 @@ import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 class IncomingCallConnection extends CallConnection {
     private final String callUUID;
     private final String payloadString;
-    private final String callerName;
     private IncomingCallNotification incomingCallNotification;
-    private Runnable mainActivityChangeListener;
 
     IncomingCallConnection(MyConnectionService service, String callUUID, String payloadString, String callerName) {
-        super(service);
+        super(service, callerName);
         this.callUUID = callUUID;
         this.payloadString = payloadString;
-        this.callerName = callerName;
     }
 
     @Override
@@ -53,16 +50,9 @@ class IncomingCallConnection extends CallConnection {
 
         cancelIncomingCallNotification();
 
-        this.setActive();
-        MyConnectionService.activeConnectionUUID = callUUID;
-
         service.showWebApp("answerCall", payloadString);
 
-        Log.d(MyConnectionService.TAG, "Starting CallAudioService...");
-        Intent intent = new Intent(service.getApplicationContext(), CallAudioService.class);
-        intent.putExtra("peerName", callerName);
-        service.startForegroundService(intent);
-
+        // Note: emitEvent() will enqueue events until the web app is ready + a listener is registered
         Log.d(MyConnectionService.TAG, "Emitting CordovaCall answer event...");
         CordovaCall.emitEvent("answer", new PluginResult(PluginResult.Status.OK, payloadString));
     }
@@ -91,9 +81,9 @@ class IncomingCallConnection extends CallConnection {
 
     @Override
     public void onStateChanged(int state) {
-        Log.d(MyConnectionService.TAG, "connection onStateChanged: " + state);
-
-        if (state == Connection.STATE_DISCONNECTED) {
+        if (state == Connection.STATE_ACTIVE) {
+            MyConnectionService.activeConnectionUUID = callUUID;
+        } else  if (state == Connection.STATE_DISCONNECTED) {
             MyConnectionService.connectionMap.remove(callUUID);
             if (MyConnectionService.activeConnectionUUID != null && MyConnectionService.activeConnectionUUID.equals(callUUID)) {
                 MyConnectionService.activeConnectionUUID = null;

--- a/src/android/IncomingCallConnection.java
+++ b/src/android/IncomingCallConnection.java
@@ -28,7 +28,7 @@ class IncomingCallConnection extends CallConnection {
         Log.d(MyConnectionService.TAG, "onShowIncomingCallUi() invoked, for call_uuid: " + callUUID);
         this.setRinging();
 
-        this.incomingCallNotification = new IncomingCallNotification(payloadString, service.getApplicationContext());
+        this.incomingCallNotification = new IncomingCallNotification(payloadString, service.getApplicationContext(), this.sessionId);
         Notification notification = this.incomingCallNotification.build();
 
         NotificationManager notificationManager = (NotificationManager) service.getSystemService(Context.NOTIFICATION_SERVICE);

--- a/src/android/IncomingCallNotification.java
+++ b/src/android/IncomingCallNotification.java
@@ -26,14 +26,16 @@ public class IncomingCallNotification {
     private String pushMessagePayload;
     private Integer notificationID;
     private Context context;
+    private String sessionId;
     private NotificationManager notificationManager;
 
     private static final String NOTIFICATION_CHANNEL_ID = "incoming_calls";
 
-    public IncomingCallNotification(String pushMessagePayload, Context context) {
+    public IncomingCallNotification(String pushMessagePayload, Context context, String sessionId) {
         this.pushMessagePayload = pushMessagePayload;
         this.notificationID = new Random().nextInt(100000) + 1;
         this.context = context;
+        this.sessionId = sessionId;
         this.notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
 
         this.createNotificationChannel();
@@ -47,6 +49,7 @@ public class IncomingCallNotification {
         Intent answerIntent = new Intent(this.context, CallActionReceiver.class);
         answerIntent.setAction("answerCall");
         answerIntent.putExtra("pushMessagePayload", this.pushMessagePayload);
+        answerIntent.putExtra("sessionId", this.sessionId);
         answerIntent.putExtra("notificationID", this.notificationID);
         PendingIntent answerPendingIntent = PendingIntent.getBroadcast(
                 this.context, 0, answerIntent,
@@ -55,7 +58,7 @@ public class IncomingCallNotification {
 
         Intent declineIntent = new Intent(this.context, CallActionReceiver.class);
         declineIntent.setAction("declineCall");
-        declineIntent.putExtra("pushMessagePayload", this.pushMessagePayload);
+        declineIntent.putExtra("sessionId", this.sessionId);
         declineIntent.putExtra("notificationID", this.notificationID);
         PendingIntent declinePendingIntent = PendingIntent.getBroadcast(
                 this.context, 1, declineIntent,

--- a/src/android/MyConnectionService.java
+++ b/src/android/MyConnectionService.java
@@ -263,8 +263,12 @@ public class MyConnectionService extends ConnectionService {
     public Connection onCreateOutgoingConnection(PhoneAccountHandle connectionManagerPhoneAccount, ConnectionRequest request) {
         Bundle extras = request.getExtras();
         String peerName = extras.getString("to", "unknown");
-        String sessionId = extras.getString("sessionId", "unknown");
+        String sessionId = extras.getString("sessionId");
 
+        if (sessionId == null) {
+            throw new RuntimeException("onCreateOutgoingConnection: Must supply a sessionId!");
+        }
+        
         final OutgoingCallConnection connection = new OutgoingCallConnection(this, peerName, sessionId);
         connection.setAddress(Uri.parse(peerName), TelecomManager.PRESENTATION_ALLOWED);
         Icon icon = CordovaCall.getIcon();

--- a/src/android/MyConnectionService.java
+++ b/src/android/MyConnectionService.java
@@ -258,7 +258,7 @@ public class MyConnectionService extends ConnectionService {
     @Override
     public Connection onCreateOutgoingConnection(PhoneAccountHandle connectionManagerPhoneAccount, ConnectionRequest request) {
         Bundle extras = request.getExtras();
-        String peerName = extras.getString("to", "uknown");
+        String peerName = extras.getString("to", "unknown");
         String sessionId = extras.getString("sessionId", "unknown");
 
         final OutgoingCallConnection connection = new OutgoingCallConnection(this, peerName, sessionId);

--- a/src/android/MyConnectionService.java
+++ b/src/android/MyConnectionService.java
@@ -131,8 +131,9 @@ public class MyConnectionService extends ConnectionService {
         } catch (JSONException e) {
             throw new RuntimeException("Failed to parse payload JSON string: " + e);
         }
-        String callUUID = payload.optString("call_uuid");
-        String sessionId = getSessionIdFromCallUUID(callUUID);
+
+        String sessionId = payload.optString("session_id", getSessionIdFromCallUUID(payload.optString("call_uuid")));
+
         return connectionMap.get(sessionId);
     }
 

--- a/src/android/MyConnectionService.java
+++ b/src/android/MyConnectionService.java
@@ -14,6 +14,7 @@ import android.telecom.CallAudioState;
 import android.telecom.Connection;
 import android.telecom.ConnectionRequest;
 import android.telecom.ConnectionService;
+import android.telecom.DisconnectCause;
 import android.telecom.PhoneAccountHandle;
 import android.telecom.StatusHints;
 import android.telecom.TelecomManager;
@@ -96,6 +97,17 @@ public class MyConnectionService extends ConnectionService {
 
                         Bundle callInfo = new Bundle();
                         callInfo.putString("payload", payloadString);
+
+                        // For robustness (avoiding violating MAX_RINGING_CALLS) + due to limitations of the current UI:
+                        // End any existing or lingering ringing connections before calling addNewIncomingCall() as it would fail:
+                        // (event: onCreateIncomingCallFailed reason: MAX_RINGING_CALLS)
+                        for (String key : connectionMap.keySet()) {
+                            Connection conn = connectionMap.get(key);
+                            if (conn.getState() == Connection.STATE_RINGING) {
+                                Log.d(TAG, "Disconnecting existing ringing connection for call_uuid: " + key + " before adding new call");
+                                conn.setDisconnected(new DisconnectCause(DisconnectCause.LOCAL)); // Connection will later be destroyed + removed (see connection.onStateChanged).
+                            }
+                        }
 
                         Log.d(TAG, "Adding new incoming connection, callUUID: " + callUUID);
 

--- a/src/android/MyConnectionService.java
+++ b/src/android/MyConnectionService.java
@@ -26,7 +26,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class MyConnectionService extends ConnectionService {
 
     static final String TAG = "MyConnectionService";
-    static final ConcurrentHashMap<String, Connection> connectionMap = new ConcurrentHashMap<String, Connection>(); // Keys are call_uuid strings
+    static final ConcurrentHashMap<String, Connection> connectionMap = new ConcurrentHashMap<String, Connection>(); // Keys are session id strings
     private static final ConcurrentHashMap<String, Boolean> connectionAddedMap = new ConcurrentHashMap<String, Boolean>(); // Keys are call_uuid strings, true if addIncomingCall called for the given call uuid.
 
     private CallActionReceiver callActionReceiver;
@@ -163,6 +163,10 @@ public class MyConnectionService extends ConnectionService {
         return activeConnectionUUID != null ? connectionMap.get(activeConnectionUUID) : null;
     }
 
+    public static Connection getConnection(String sessionId) {
+        return connectionMap.get(sessionId);
+    }
+
     public static void endActiveCall() {
         if (activeConnectionUUID != null) {
             Connection conn = connectionMap.get(activeConnectionUUID);
@@ -219,7 +223,15 @@ public class MyConnectionService extends ConnectionService {
 
         Log.d(TAG, "Created connection for callUUID: " + callUUID);
         connection.setConnectionProperties(Connection.PROPERTY_SELF_MANAGED);
-        connectionMap.put(callUUID, connection);
+
+        int indexOfSeparator = callUUID.indexOf(";");
+        if (indexOfSeparator != -1) {
+            Log.e(TAG, "callUUID does not have a ; can not properly extract a session id!");
+            connectionMap.put(callUUID, connection);
+        } else {
+            String sessionId = callUUID.substring(0, indexOfSeparator);
+            connectionMap.put(sessionId, connection);
+        }
 
         CordovaCall.emitEvent("receiveCall", new PluginResult(PluginResult.Status.OK, "receiveCall event called successfully"));
 
@@ -236,10 +248,12 @@ public class MyConnectionService extends ConnectionService {
 
     @Override
     public Connection onCreateOutgoingConnection(PhoneAccountHandle connectionManagerPhoneAccount, ConnectionRequest request) {
-        String peerName = request.getExtras().getString("to", "uknown");
+        Bundle extras = request.getExtras();
+        String peerName = extras.getString("to", "uknown");
+        String sessionId = extras.getString("sessionId", "unknown");
 
         final OutgoingCallConnection connection = new OutgoingCallConnection(this, peerName);
-        connection.setAddress(Uri.parse(request.getExtras().getString("to")), TelecomManager.PRESENTATION_ALLOWED);
+        connection.setAddress(Uri.parse(peerName), TelecomManager.PRESENTATION_ALLOWED);
         Icon icon = CordovaCall.getIcon();
         if(icon != null) {
             StatusHints statusHints = new StatusHints((CharSequence)"", icon, new Bundle());
@@ -258,6 +272,8 @@ public class MyConnectionService extends ConnectionService {
 
         connection.setDialing();
         CordovaCall.emitEvent("sendCall", new PluginResult(PluginResult.Status.OK, "sendCall event called successfully"));
+
+        connectionMap.put(sessionId, connection);
 
         return connection;
     }

--- a/src/android/MyConnectionService.java
+++ b/src/android/MyConnectionService.java
@@ -223,10 +223,10 @@ public class MyConnectionService extends ConnectionService {
     public static String getSessionIdFromCallUUID(String callUUID) {
         int indexOfSeparator = callUUID.indexOf(";");
         if (indexOfSeparator != -1) {
+            return callUUID.substring(0, indexOfSeparator);
+        } else {
             Log.e(TAG, "callUUID does not have a ; can not properly extract a session id!");
             return callUUID; // For robustness just use something
-        } else {
-            return callUUID.substring(0, indexOfSeparator);
         }
     }
 

--- a/src/android/MyConnectionService.java
+++ b/src/android/MyConnectionService.java
@@ -68,7 +68,7 @@ public class MyConnectionService extends ConnectionService {
             }
 
             String callUUID = payload.optString("call_uuid", "");
-            String sessionId = getSessionIdFromCallUUID(callUUID);
+            String sessionId = payload.optString("session_id", getSessionIdFromCallUUID(callUUID));
 
             if (payload.optBoolean("dismiss", false)) {
                 Log.d(TAG, "received intent with payload.dismiss indicating call is dismissed, call_uuid: " + callUUID);
@@ -266,7 +266,7 @@ public class MyConnectionService extends ConnectionService {
         if (sessionId == null) {
             throw new RuntimeException("onCreateOutgoingConnection: Must supply a sessionId!");
         }
-        
+
         final OutgoingCallConnection connection = new OutgoingCallConnection(this, peerName, sessionId);
         connection.setAddress(Uri.parse(peerName), TelecomManager.PRESENTATION_ALLOWED);
         Icon icon = CordovaCall.getIcon();

--- a/src/android/MyConnectionService.java
+++ b/src/android/MyConnectionService.java
@@ -124,12 +124,6 @@ public class MyConnectionService extends ConnectionService {
         return START_STICKY; // System will attempt to re-create the service if it is killed.
     }
 
-    static String activeSessionId;
-
-    public void setActiveSessionId(String sessionId) {
-        MyConnectionService.activeSessionId = sessionId;
-    }
-
     public static Connection getConnectionByPayload(String pushMessagePayload) {
         JSONObject payload;
         try {
@@ -167,9 +161,16 @@ public class MyConnectionService extends ConnectionService {
         this.startActivity(intent);
     }
 
-    // Returns the connection for the active session (or null if none)
+    // Returns the connection for the active session (or null if none).
+    // connectionMap is a ConcurrentHashMap so iteration is thread-safe.
+    // Per Android Telecom semantics, at most one connection should be STATE_ACTIVE at a time.
     public static Connection getConnection() {
-        return activeSessionId != null ? connectionMap.get(activeSessionId) : null;
+        for (Connection conn : connectionMap.values()) {
+            if (conn.getState() == Connection.STATE_ACTIVE) {
+                return conn;
+            }
+        }
+        return null;
     }
 
     public static Connection getConnection(String sessionId) {
@@ -177,9 +178,6 @@ public class MyConnectionService extends ConnectionService {
     }
 
     public static void onConnectionDisconnected(String sessionId) {
-        if (sessionId.equals(activeSessionId)) {
-            activeSessionId = null;
-        }
         Log.d(TAG, "Removing CallConnection from connectionMap, sessionId: " + sessionId);
         connectionMap.remove(sessionId);
     }

--- a/src/android/MyConnectionService.java
+++ b/src/android/MyConnectionService.java
@@ -1,20 +1,14 @@
 package com.dmarc.cordovacall;
 
-import static android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE;
-import static android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_PHONE_CALL;
-
 import org.apache.cordova.PluginResult;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import android.app.NotificationChannel;
 import android.content.Intent;
 import android.content.Context;
 import android.content.IntentFilter;
 import android.content.pm.PackageManager;
 import android.graphics.drawable.Icon;
-import android.media.AudioManager;
-import android.os.Build;
 import android.os.Bundle;
 import android.telecom.CallAudioState;
 import android.telecom.Connection;
@@ -24,14 +18,8 @@ import android.telecom.DisconnectCause;
 import android.telecom.PhoneAccountHandle;
 import android.telecom.StatusHints;
 import android.telecom.TelecomManager;
-import android.os.Handler;
 import android.net.Uri;
 import android.util.Log;
-
-import androidx.annotation.NonNull;
-import androidx.core.app.NotificationCompat;
-import androidx.lifecycle.DefaultLifecycleObserver;
-import androidx.lifecycle.LifecycleOwner;
 
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -259,18 +247,15 @@ public class MyConnectionService extends ConnectionService {
 
     @Override
     public Connection onCreateOutgoingConnection(PhoneAccountHandle connectionManagerPhoneAccount, ConnectionRequest request) {
-        final OutgoingCallConnection connection = new OutgoingCallConnection(this);
+        String peerName = request.getExtras().getString("to", "uknown");
+
+        final OutgoingCallConnection connection = new OutgoingCallConnection(this, peerName);
         connection.setAddress(Uri.parse(request.getExtras().getString("to")), TelecomManager.PRESENTATION_ALLOWED);
         Icon icon = CordovaCall.getIcon();
         if(icon != null) {
             StatusHints statusHints = new StatusHints((CharSequence)"", icon, new Bundle());
             connection.setStatusHints(statusHints);
         }
-
-        Log.d(TAG, "Starting CallAudioService foreground service...");
-        Intent intent = new Intent(getApplicationContext(), CallAudioService.class);
-        intent.putExtra("peerName", request.getExtras().getString("to", "uknown"));
-        startForegroundService(intent);
 
         // Set capabilities to indicate this handles audio
         connection.setConnectionCapabilities(
@@ -285,7 +270,6 @@ public class MyConnectionService extends ConnectionService {
         connection.setDialing();
         CordovaCall.emitEvent("sendCall", new PluginResult(PluginResult.Status.OK, "sendCall event called successfully"));
 
-        activeOutgoingConnection = connection;
         return connection;
     }
 }

--- a/src/android/MyConnectionService.java
+++ b/src/android/MyConnectionService.java
@@ -14,7 +14,6 @@ import android.telecom.CallAudioState;
 import android.telecom.Connection;
 import android.telecom.ConnectionRequest;
 import android.telecom.ConnectionService;
-import android.telecom.DisconnectCause;
 import android.telecom.PhoneAccountHandle;
 import android.telecom.StatusHints;
 import android.telecom.TelecomManager;
@@ -30,10 +29,6 @@ public class MyConnectionService extends ConnectionService {
     private static final ConcurrentHashMap<String, Boolean> connectionAddedMap = new ConcurrentHashMap<String, Boolean>(); // Keys are call_uuid strings, true if addIncomingCall called for the given call uuid.
 
     private CallActionReceiver callActionReceiver;
-
-    // TODO: store the outgoing connections in connectionMap() to do that we will need a call UUID which we could pass into the app through sendCall
-    // we can then get rid of this variable, and just always use connectionMap() + connection UUIDs to access both incoming and outgoing connections.
-    static Connection activeOutgoingConnection;
 
     @Override
     public void onCreate() {
@@ -115,7 +110,7 @@ public class MyConnectionService extends ConnectionService {
         return START_STICKY; // System will attempt to re-create the service if it is killed.
     }
 
-    static String activeConnectionUUID;
+    static String activeSessionId;
 
     public static Connection getConnectionByPayload(String pushMessagePayload) {
         JSONObject payload;
@@ -125,7 +120,8 @@ public class MyConnectionService extends ConnectionService {
             throw new RuntimeException("Failed to parse payload JSON string: " + e);
         }
         String callUUID = payload.optString("call_uuid");
-        return connectionMap.get(callUUID);
+        String sessionId = getSessionIdFromCallUUID(callUUID);
+        return connectionMap.get(sessionId);
     }
 
     public void showWebApp(String userAction, String payload) {
@@ -153,28 +149,20 @@ public class MyConnectionService extends ConnectionService {
         this.startActivity(intent);
     }
 
+    // Returns the connection for the active session (or null if none)
     public static Connection getConnection() {
-        // Note: if your currently in an active connection,
-        // calling TelecomManager.addCall() would fail
-        // Thus you can really have either (but not both) an active outgoing or an active incoming connection
-        if (activeOutgoingConnection != null) {
-            return activeOutgoingConnection;
-        }
-        return activeConnectionUUID != null ? connectionMap.get(activeConnectionUUID) : null;
+        return activeSessionId != null ? connectionMap.get(activeSessionId) : null;
     }
 
     public static Connection getConnection(String sessionId) {
         return connectionMap.get(sessionId);
     }
 
-    public static void endActiveCall() {
-        if (activeConnectionUUID != null) {
-            Connection conn = connectionMap.get(activeConnectionUUID);
-            conn.setDisconnected(new DisconnectCause(DisconnectCause.LOCAL));
+    public static void onConnectionDisconnected(String sessionId) {
+        if (sessionId.equals(activeSessionId)) {
+            activeSessionId = null;
         }
-        if (activeOutgoingConnection != null) {
-            activeOutgoingConnection.setDisconnected(new DisconnectCause(DisconnectCause.LOCAL));
-        }
+        connectionMap.remove(sessionId);
     }
 
     void handleCallAudioStateChanged(CallAudioState state) {
@@ -211,7 +199,8 @@ public class MyConnectionService extends ConnectionService {
 
         connectionAddedMap.remove(callUUID);
 
-        final IncomingCallConnection connection = new IncomingCallConnection(this, callUUID, payloadString, callerName);
+        String sessionId = getSessionIdFromCallUUID(callUUID);
+        final IncomingCallConnection connection = new IncomingCallConnection(this, callUUID, payloadString, callerName, sessionId);
 
         connection.setCallerDisplayName(callerName, TelecomManager.PRESENTATION_ALLOWED);
 
@@ -224,18 +213,21 @@ public class MyConnectionService extends ConnectionService {
         Log.d(TAG, "Created connection for callUUID: " + callUUID);
         connection.setConnectionProperties(Connection.PROPERTY_SELF_MANAGED);
 
-        int indexOfSeparator = callUUID.indexOf(";");
-        if (indexOfSeparator != -1) {
-            Log.e(TAG, "callUUID does not have a ; can not properly extract a session id!");
-            connectionMap.put(callUUID, connection);
-        } else {
-            String sessionId = callUUID.substring(0, indexOfSeparator);
-            connectionMap.put(sessionId, connection);
-        }
+        connectionMap.put(sessionId, connection);
 
         CordovaCall.emitEvent("receiveCall", new PluginResult(PluginResult.Status.OK, "receiveCall event called successfully"));
 
         return connection;
+    }
+
+    public static String getSessionIdFromCallUUID(String callUUID) {
+        int indexOfSeparator = callUUID.indexOf(";");
+        if (indexOfSeparator != -1) {
+            Log.e(TAG, "callUUID does not have a ; can not properly extract a session id!");
+            return callUUID; // For robustness just use something
+        } else {
+            return callUUID.substring(0, indexOfSeparator);
+        }
     }
 
     @Override
@@ -252,7 +244,7 @@ public class MyConnectionService extends ConnectionService {
         String peerName = extras.getString("to", "uknown");
         String sessionId = extras.getString("sessionId", "unknown");
 
-        final OutgoingCallConnection connection = new OutgoingCallConnection(this, peerName);
+        final OutgoingCallConnection connection = new OutgoingCallConnection(this, peerName, sessionId);
         connection.setAddress(Uri.parse(peerName), TelecomManager.PRESENTATION_ALLOWED);
         Icon icon = CordovaCall.getIcon();
         if(icon != null) {

--- a/src/android/MyConnectionService.java
+++ b/src/android/MyConnectionService.java
@@ -173,6 +173,17 @@ public class MyConnectionService extends ConnectionService {
         return null;
     }
 
+    // Returns the number of connections currently in STATE_ACTIVE.
+    public static int getActiveCallCount() {
+        int count = 0;
+        for (Connection conn : connectionMap.values()) {
+            if (conn.getState() == Connection.STATE_ACTIVE) {
+                count++;
+            }
+        }
+        return count;
+    }
+
     public static Connection getConnection(String sessionId) {
         return connectionMap.get(sessionId);
     }

--- a/src/android/MyConnectionService.java
+++ b/src/android/MyConnectionService.java
@@ -126,6 +126,10 @@ public class MyConnectionService extends ConnectionService {
 
     static String activeSessionId;
 
+    public void setActiveSessionId(String sessionId) {
+        MyConnectionService.activeSessionId = sessionId;
+    }
+
     public static Connection getConnectionByPayload(String pushMessagePayload) {
         JSONObject payload;
         try {

--- a/src/android/MyConnectionService.java
+++ b/src/android/MyConnectionService.java
@@ -242,7 +242,7 @@ public class MyConnectionService extends ConnectionService {
         if (parts.length >= 2) {
             return parts[0] + parts[1];
         } else {
-            Log.e(TAG, "callUUID does not have a ; can not properly extract a session id!");
+            Log.e(TAG, "can not extract sessionId from callUUID: " + callUUID);
             return callUUID; // For robustness just use something
         }
     }

--- a/src/android/MyConnectionService.java
+++ b/src/android/MyConnectionService.java
@@ -237,9 +237,10 @@ public class MyConnectionService extends ConnectionService {
     }
 
     public static String getSessionIdFromCallUUID(String callUUID) {
-        int indexOfSeparator = callUUID.indexOf(";");
-        if (indexOfSeparator != -1) {
-            return callUUID.substring(0, indexOfSeparator);
+        String[] parts = callUUID.split(";");
+
+        if (parts.length >= 2) {
+            return parts[0] + parts[1];
         } else {
             Log.e(TAG, "callUUID does not have a ; can not properly extract a session id!");
             return callUUID; // For robustness just use something

--- a/src/android/MyConnectionService.java
+++ b/src/android/MyConnectionService.java
@@ -68,10 +68,12 @@ public class MyConnectionService extends ConnectionService {
             }
 
             String callUUID = payload.optString("call_uuid", "");
+            String sessionId = getSessionIdFromCallUUID(callUUID);
 
             if (payload.optBoolean("dismiss", false)) {
                 Log.d(TAG, "received intent with payload.dismiss indicating call is dismissed, call_uuid: " + callUUID);
-                Connection conn = connectionMap.get(callUUID);
+
+                Connection conn = connectionMap.get(sessionId);
                 if (conn == null) {
                     Log.e(TAG, "Cannot disconnect. No connection found with call_uuid: " + callUUID);
                 } else {
@@ -83,7 +85,7 @@ public class MyConnectionService extends ConnectionService {
                     }
                 }
             } else {
-                if (connectionMap.get(callUUID) != null) {
+                if (connectionMap.get(sessionId) != null) {
                     Log.d(TAG, "A connection is already created for call_uuid: " + callUUID);
                 } else {
                     if (connectionAddedMap.containsKey(callUUID)) {
@@ -174,6 +176,7 @@ public class MyConnectionService extends ConnectionService {
         if (sessionId.equals(activeSessionId)) {
             activeSessionId = null;
         }
+        Log.d(TAG, "Removing CallConnection from connectionMap, sessionId: " + sessionId);
         connectionMap.remove(sessionId);
     }
 
@@ -225,6 +228,7 @@ public class MyConnectionService extends ConnectionService {
         Log.d(TAG, "Created connection for callUUID: " + callUUID);
         connection.setConnectionProperties(Connection.PROPERTY_SELF_MANAGED);
 
+        Log.d(TAG, "Adding IncomingCallConnection to connectionMap, sessionId: " + sessionId);
         connectionMap.put(sessionId, connection);
 
         CordovaCall.emitEvent("receiveCall", new PluginResult(PluginResult.Status.OK, "receiveCall event called successfully"));
@@ -277,6 +281,7 @@ public class MyConnectionService extends ConnectionService {
         connection.setDialing();
         CordovaCall.emitEvent("sendCall", new PluginResult(PluginResult.Status.OK, "sendCall event called successfully"));
 
+        Log.d(TAG, "Adding OutgoingCallConnection to connectionMap, sessionId: " + sessionId);
         connectionMap.put(sessionId, connection);
 
         return connection;

--- a/src/android/MyConnectionService.java
+++ b/src/android/MyConnectionService.java
@@ -102,17 +102,6 @@ public class MyConnectionService extends ConnectionService {
                         Bundle callInfo = new Bundle();
                         callInfo.putString("payload", payloadString);
 
-                        // For robustness (avoiding violating MAX_RINGING_CALLS) + due to limitations of the current UI:
-                        // End any existing or lingering ringing connections before calling addNewIncomingCall() as it would fail:
-                        // (event: onCreateIncomingCallFailed reason: MAX_RINGING_CALLS)
-                        for (String key : connectionMap.keySet()) {
-                            Connection conn = connectionMap.get(key);
-                            if (conn.getState() == Connection.STATE_RINGING) {
-                                Log.d(TAG, "Disconnecting existing ringing connection for call_uuid: " + key + " before adding new call");
-                                conn.setDisconnected(new DisconnectCause(DisconnectCause.LOCAL)); // Connection will later be destroyed + removed (see connection.onStateChanged).
-                            }
-                        }
-
                         Log.d(TAG, "Adding new incoming connection, callUUID: " + callUUID);
 
                         // After this a new connection is created (see onCreateIncomingConnection below)

--- a/src/android/OngoingCallNotification.java
+++ b/src/android/OngoingCallNotification.java
@@ -20,18 +20,20 @@ public class OngoingCallNotification {
     private static final String TAG = "OngoingCallNotification";
 
     private String peerName;
+    private String sessionId;
     private Integer notificationID;
     private Context context;
     private NotificationManager notificationManager;
 
     private static final String NOTIFICATION_CHANNEL_ID = "ongoing_calls";
 
-    public OngoingCallNotification(Context context, String peerName) {
+    public OngoingCallNotification(Context context, String peerName, String sessionId) {
         this.notificationID = new Random().nextInt(100000) + 1;
         this.context = context;
         this.notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
 
         this.peerName = peerName;
+        this.sessionId = sessionId;
 
         this.createNotificationChannel();
     }
@@ -40,6 +42,7 @@ public class OngoingCallNotification {
         Intent hangupIntent = new Intent(this.context, CallActionReceiver.class);
         hangupIntent.setAction("hangUpCall");
         hangupIntent.putExtra("notificationID", this.notificationID);
+        hangupIntent.putExtra("sessionId", this.sessionId);
         PendingIntent hangupPendingIntent = PendingIntent.getBroadcast(
                 this.context, 0, hangupIntent,
                 PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE

--- a/src/android/OutgoingCallConnection.java
+++ b/src/android/OutgoingCallConnection.java
@@ -1,21 +1,12 @@
 package com.dmarc.cordovacall;
 
-import android.telecom.Connection;
-
 class OutgoingCallConnection extends CallConnection {
-    OutgoingCallConnection(MyConnectionService service, String peerName) {
-        super(service, peerName);
+    OutgoingCallConnection(MyConnectionService service, String peerName, String sessionId) {
+        super(service, peerName, sessionId);
     }
 
     @Override
     public void onStateChanged(int state) {
-        if (state == Connection.STATE_ACTIVE) {
-            MyConnectionService.activeOutgoingConnection = this;
-        } else if (state == Connection.STATE_DISCONNECTED) {
-            // In all cases when connection transitions to STATE_DISCONNECTED (both onAbort() and onDisconnect())
-            // Ensure the connection is destroyed, etc.
-            MyConnectionService.activeOutgoingConnection = null;
-        }
         super.onStateChanged(state);
     }
 }

--- a/src/android/OutgoingCallConnection.java
+++ b/src/android/OutgoingCallConnection.java
@@ -3,17 +3,18 @@ package com.dmarc.cordovacall;
 import android.telecom.Connection;
 
 class OutgoingCallConnection extends CallConnection {
-    OutgoingCallConnection(MyConnectionService service) {
-        super(service);
+    OutgoingCallConnection(MyConnectionService service, String peerName) {
+        super(service, peerName);
     }
 
     @Override
     public void onStateChanged(int state) {
-        if (state == Connection.STATE_DISCONNECTED) {
+        if (state == Connection.STATE_ACTIVE) {
+            MyConnectionService.activeOutgoingConnection = this;
+        } else if (state == Connection.STATE_DISCONNECTED) {
             // In all cases when connection transitions to STATE_DISCONNECTED (both onAbort() and onDisconnect())
             // Ensure the connection is destroyed, etc.
             MyConnectionService.activeOutgoingConnection = null;
-            MyConnectionService.activeConnectionUUID = null;
         }
         super.onStateChanged(state);
     }

--- a/www/CordovaCall.js
+++ b/www/CordovaCall.js
@@ -106,6 +106,14 @@ exports.callNumber = function (to, success, error) {
   exec(success, error, "CordovaCall", "callNumber", [to]);
 };
 
+exports.hold = function (sessionId, success, error) {
+  exec(success, error, "CordovaCall", "hold", [sessionId]);
+};
+
+exports.unhold = function (sessionId, success, error) {
+  exec(success, error, "CordovaCall", "unhold", [sessionId]);
+};
+
 exports.on = function (e, f) {
   var success = function (message) {
     f(message);


### PR DESCRIPTION
- Fixes logic between onAnswer ... setActive (before native layer was immediately setting connection to active, rather than waiting on connectCall action from facetalk).

- Uses sessionIds to track both incoming and outgoing call connections (and updates everything accordingly to use this)

- Hooks up the "hold" and "unhold" CordovaCall actions to set the corresponding Android connection to the right state in response to these actions

- Re-uses the Web-based UI that allows you to switch between calls, see held calls, etc. (which is pretty similar to the mockup anyway)

- Generalizes the starting/stopping of CallAudioService a bit better.

Dependant on Rex's facetalk PR:
https://github.com/iotum/facetalk/pull/11766

Re-uses the calls from javascript to CordovaCall hold/unhold in response to jsSIP sessions changing.

and dups a small amount of the iOS PR (to update the www/CordovaCall.js plugin API):
https://github.com/iotum/cordova-plugin-callkit/pull/67  (see last file in this PR)

- lets' merge the iOS one first :)



TO COME:

Logic to handle case where you can't answer any more calls due to MAX_HOLD_CALLS (requires some new UI that I'll be working on in the form of a modal asking the user which call they want to end to accept another call).