### PR TITLE
[Android] Remove Redundant/Incorrect Hangup Callback Logic

### DIFF
--- a/src/android/CordovaCall.java
+++ b/src/android/CordovaCall.java
@@ -266,17 +266,6 @@ public class CordovaCall extends CordovaPlugin {
                 this.callbackContext.error("No call with this sessionId exists for you to end");
             } else {
                 conn.onDisconnect();
-
-                ArrayList<CallbackContext> callbackContexts = CordovaCall.getCallbackContexts().get("hangup");
-                for (final CallbackContext cbContext : callbackContexts) {
-                    cordova.getThreadPool().execute(new Runnable() {
-                        public void run() {
-                            PluginResult result = new PluginResult(PluginResult.Status.OK, "hangup event called successfully");
-                            result.setKeepCallback(true);
-                            cbContext.sendPluginResult(result);
-                        }
-                    });
-                }
                 this.callbackContext.success("Call ended successfully");
             }
             return true;


### PR DESCRIPTION
It's redundant code cause technical issues and confusion.

Redundant to this code in the connection service which does that:

<img width="1174" height="197" alt="Screenshot from 2026-03-09 18-04-04" src="https://github.com/user-attachments/assets/f086b495-00a6-4aee-907a-130c83f9c354" />

(which is more concise and re-uses emitEvent)