### PR TITLE
[Android] Remove fallback to get sessionId from callUUID + Improve Connection State Change Listener/Broadcaster

### DIFF
--- a/src/android/CallConnection.java
+++ b/src/android/CallConnection.java
@@ -9,6 +9,8 @@ import android.telecom.Connection;
 import android.telecom.DisconnectCause;
 import android.util.Log;
 
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
+
 /**
  * Base class for both incoming and outgoing connections.
  * Holds the common logic shared between IncomingCallConnection and OutgoingCallConnection.
@@ -67,5 +69,11 @@ class CallConnection extends Connection {
 
             MyConnectionService.onConnectionDisconnected(this.sessionId);
         }
+
+        Log.d(MyConnectionService.TAG, "broadcasting connection_state_changed sessionId: " + this.sessionId + " state: " + state);
+        Intent intent = new Intent("connection_state_changed");
+        intent.putExtra("sessionId", this.sessionId);
+        intent.putExtra("state", state);
+        LocalBroadcastManager.getInstance(service.getApplicationContext()).sendBroadcast(intent);
     }
 }

--- a/src/android/IncomingCallActivity.java
+++ b/src/android/IncomingCallActivity.java
@@ -8,7 +8,6 @@ import android.content.IntentFilter;
 import android.graphics.Color;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.GradientDrawable;
-import android.os.Build;
 import android.os.Bundle;
 import android.telecom.Connection;
 import android.util.Log;
@@ -40,27 +39,10 @@ public class IncomingCallActivity extends AppCompatActivity {
             String action = intent.getAction();
             Log.d(TAG, "callStateReciever onReceive: " + action);
             if ("connection_state_changed".equals(action)) {
-                String payload = getPushMessagePayload();
-                JSONObject payloadJSON;
-                try {
-                    payloadJSON = new JSONObject(payload);
-                } catch (JSONException e) {
-                    throw new RuntimeException("callStateReciever: unable to parse payload json: " + e);
-                }
-
-                String callUUID;
-                try {
-                    callUUID = payloadJSON.getString("call_uuid");
-                } catch (JSONException e) {
-                    throw new RuntimeException("callStateReceive: unable to get call_uuid from payload json");
-                }
-
-                if (callUUID.equals(intent.getStringExtra("call_uuid"))) {
-                    int newState = intent.getIntExtra("state", 0);
-                    if (newState == Connection.STATE_DISCONNECTED) {
-                        Log.d(TAG, "closing activity as call was disconnected");
-                        finishAndRemoveTask();
-                    }
+                Connection conn = MyConnectionService.getConnection(intent.getStringExtra("sessionId"));
+                if (conn.getState() == Connection.STATE_DISCONNECTED) {
+                    Log.d(TAG, "closing activity as call was disconnected");
+                    finishAndRemoveTask();
                 }
             }
         }
@@ -75,7 +57,10 @@ public class IncomingCallActivity extends AppCompatActivity {
         Log.d(TAG, "Registering callStateReciever");
         LocalBroadcastManager.getInstance(this.getApplicationContext()).registerReceiver(callStateReceiver, filter);
 
-        Connection connection = MyConnectionService.getConnectionByPayload(this.getPushMessagePayload());
+        String sessionId = this.getIntent().getStringExtra("sessionId");
+
+        Connection connection = MyConnectionService.getConnection(sessionId);
+
         if (connection == null) {
             Log.d(TAG, "Exiting, connection no longer exists.");
             finishAndRemoveTask();

--- a/src/android/IncomingCallActivity.java
+++ b/src/android/IncomingCallActivity.java
@@ -39,7 +39,7 @@ public class IncomingCallActivity extends AppCompatActivity {
         @Override
         public void onReceive(Context context, Intent intent) {
             String action = intent.getAction();
-            Log.d(TAG, "callStateReciever onReceive: " + action);
+            Log.d(TAG, "callStateReceiver onReceive: " + action);
             if ("connection_state_changed".equals(action) && sessionId.equals(intent.getStringExtra("sessionId"))) {
                 int newState = intent.getIntExtra("state", 0);
                 if (newState == Connection.STATE_DISCONNECTED) {

--- a/src/android/IncomingCallActivity.java
+++ b/src/android/IncomingCallActivity.java
@@ -33,14 +33,16 @@ public class IncomingCallActivity extends AppCompatActivity {
 
     private int callerNameViewID;
 
+    private String sessionId; // sessionId of the ringing call associated with this acivity
+
     private final BroadcastReceiver callStateReceiver = new BroadcastReceiver() {
         @Override
         public void onReceive(Context context, Intent intent) {
             String action = intent.getAction();
             Log.d(TAG, "callStateReciever onReceive: " + action);
-            if ("connection_state_changed".equals(action)) {
-                Connection conn = MyConnectionService.getConnection(intent.getStringExtra("sessionId"));
-                if (conn.getState() == Connection.STATE_DISCONNECTED) {
+            if ("connection_state_changed".equals(action) && sessionId.equals(intent.getStringExtra("sessionId"))) {
+                int newState = intent.getIntExtra("state", 0);
+                if (newState == Connection.STATE_DISCONNECTED) {
                     Log.d(TAG, "closing activity as call was disconnected");
                     finishAndRemoveTask();
                 }
@@ -52,12 +54,14 @@ public class IncomingCallActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
+        this.sessionId = this.getIntent().getStringExtra("sessionId");
+
         IntentFilter filter = new IntentFilter("connection_state_changed");
 
         Log.d(TAG, "Registering callStateReciever");
         LocalBroadcastManager.getInstance(this.getApplicationContext()).registerReceiver(callStateReceiver, filter);
 
-        String sessionId = this.getIntent().getStringExtra("sessionId");
+
 
         Connection connection = MyConnectionService.getConnection(sessionId);
 
@@ -176,6 +180,8 @@ public class IncomingCallActivity extends AppCompatActivity {
     public void onNewIntent(@NonNull Intent intent, @NonNull ComponentCaller caller) {
         super.onNewIntent(intent, caller);
         this.setIntent(intent); // So that future calls to this.getIntent() return the new intent, and not the initial intent of the activity
+
+        this.sessionId = intent.getStringExtra("sessionId");
 
         this.updateCallerNameView();
     }

--- a/src/android/IncomingCallConnection.java
+++ b/src/android/IncomingCallConnection.java
@@ -5,12 +5,9 @@ import org.apache.cordova.PluginResult;
 import android.app.Notification;
 import android.app.NotificationManager;
 import android.content.Context;
-import android.content.Intent;
 import android.telecom.Connection;
 import android.telecom.DisconnectCause;
 import android.util.Log;
-
-import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 class IncomingCallConnection extends CallConnection {
     private final String callUUID;
@@ -86,11 +83,5 @@ class IncomingCallConnection extends CallConnection {
         }
 
         super.onStateChanged(state);
-
-        Log.d(MyConnectionService.TAG, "broadcasting connection_state_changed call_uuid: " + callUUID + " state: " + state);
-        Intent intent = new Intent("connection_state_changed");
-        intent.putExtra("call_uuid", callUUID);
-        intent.putExtra("state", state);
-        LocalBroadcastManager.getInstance(service.getApplicationContext()).sendBroadcast(intent);
     }
 }

--- a/src/android/IncomingCallNotification.java
+++ b/src/android/IncomingCallNotification.java
@@ -95,6 +95,7 @@ public class IncomingCallNotification {
             builder.setStyle(NotificationCompat.CallStyle.forIncomingCall(callerPerson, declinePendingIntent, answerPendingIntent));
 
             Intent fullScreenIntent = new Intent(this.context, IncomingCallActivity.class);
+            fullScreenIntent.putExtra("sessionId", this.sessionId);
             fullScreenIntent.putExtra("pushMessagePayload", this.pushMessagePayload);
             fullScreenIntent.setFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
             PendingIntent fullScreenPendingIntent = PendingIntent.getActivity(

--- a/src/android/MyConnectionService.java
+++ b/src/android/MyConnectionService.java
@@ -68,7 +68,12 @@ public class MyConnectionService extends ConnectionService {
             }
 
             String callUUID = payload.optString("call_uuid", "");
-            String sessionId = payload.optString("session_id", getSessionIdFromCallUUID(callUUID));
+            String sessionId = null;
+            try {
+                sessionId = payload.getString("session_id");
+            } catch (JSONException e) {
+                throw new RuntimeException("Unable to add incoming connection - no session_id found in payload");
+            }
 
             if (payload.optBoolean("dismiss", false)) {
                 Log.d(TAG, "received intent with payload.dismiss indicating call is dismissed, call_uuid: " + callUUID);
@@ -122,19 +127,6 @@ public class MyConnectionService extends ConnectionService {
         }
 
         return START_STICKY; // System will attempt to re-create the service if it is killed.
-    }
-
-    public static Connection getConnectionByPayload(String pushMessagePayload) {
-        JSONObject payload;
-        try {
-            payload = new JSONObject(pushMessagePayload);
-        } catch (JSONException e) {
-            throw new RuntimeException("Failed to parse payload JSON string: " + e);
-        }
-
-        String sessionId = payload.optString("session_id", getSessionIdFromCallUUID(payload.optString("call_uuid")));
-
-        return connectionMap.get(sessionId);
     }
 
     public void showWebApp(String userAction, String payload) {

--- a/src/android/MyConnectionService.java
+++ b/src/android/MyConnectionService.java
@@ -220,7 +220,12 @@ public class MyConnectionService extends ConnectionService {
 
         connectionAddedMap.remove(callUUID);
 
-        String sessionId = getSessionIdFromCallUUID(callUUID);
+        String sessionId = null;
+        try {
+            sessionId = payload.getString("session_id");
+        } catch (JSONException e) {
+            throw new RuntimeException("onCreateIncomingConnection: no session_id in payload, unable to create IncomingCallConnection");
+        }
         final IncomingCallConnection connection = new IncomingCallConnection(this, callUUID, payloadString, callerName, sessionId);
 
         connection.setCallerDisplayName(callerName, TelecomManager.PRESENTATION_ALLOWED);
@@ -240,17 +245,6 @@ public class MyConnectionService extends ConnectionService {
         CordovaCall.emitEvent("receiveCall", new PluginResult(PluginResult.Status.OK, "receiveCall event called successfully"));
 
         return connection;
-    }
-
-    public static String getSessionIdFromCallUUID(String callUUID) {
-        String[] parts = callUUID.split(";");
-
-        if (parts.length >= 2) {
-            return parts[0] + parts[1];
-        } else {
-            Log.e(TAG, "can not extract sessionId from callUUID: " + callUUID);
-            return callUUID; // For robustness just use something
-        }
     }
 
     @Override

--- a/src/android/MyConnectionService.java
+++ b/src/android/MyConnectionService.java
@@ -72,7 +72,7 @@ public class MyConnectionService extends ConnectionService {
             try {
                 sessionId = payload.getString("session_id");
             } catch (JSONException e) {
-                throw new RuntimeException("Unable to add incoming connection - no session_id found in payload");
+                throw new RuntimeException("Unable to add incoming connection - no session_id found in payload: " + payloadString);
             }
 
             if (payload.optBoolean("dismiss", false)) {


### PR DESCRIPTION
- Improves the Connection state listener/broadcaster:
   - use session IDs rather than connection ids
   - broadcast for both incoming and outgoing connections (move broadcast logic to superclass)
   - simplifies logic in broadcast receiver in IncomingCallActivity

- Removes getConnectionByPayload() now not needed

- Removes fallback logic to get sessionId from callUUId (will always get through payload.session_id)