### PR TITLE
CordovaCall: initialize arraylist of callback context for hold/unhold…

### DIFF
--- a/src/android/CordovaCall.java
+++ b/src/android/CordovaCall.java
@@ -61,19 +61,6 @@ public class CordovaCall extends CordovaPlugin {
     private String from;
     private String realCallTo;
     private static HashMap<String, ArrayList<CallbackContext>> callbackContextMap = new HashMap<String, ArrayList<CallbackContext>>();
-    static {
-        callbackContextMap.put("receiveCall", new ArrayList<CallbackContext>());
-        callbackContextMap.put("answer", new ArrayList<CallbackContext>());
-        callbackContextMap.put("reject", new ArrayList<CallbackContext>());
-        callbackContextMap.put("mute", new ArrayList<CallbackContext>());
-        callbackContextMap.put("unmute", new ArrayList<CallbackContext>());
-        callbackContextMap.put("hold", new ArrayList<CallbackContext>());
-        callbackContextMap.put("unhold", new ArrayList<CallbackContext>());
-        callbackContextMap.put("hangup", new ArrayList<CallbackContext>());
-        callbackContextMap.put("sendCall", new ArrayList<CallbackContext>());
-        callbackContextMap.put("DTMF", new ArrayList<CallbackContext>());
-        callbackContextMap.put("audioRouteChange", new ArrayList<CallbackContext>());
-    }
     private static ArrayList<HashMap> enqueuedEvents = new ArrayList<HashMap>();
     private static CordovaInterface cordovaInterface;
     private static CordovaWebView cordovaWebView;
@@ -89,7 +76,7 @@ public class CordovaCall extends CordovaPlugin {
 
     public static void emitEvent(String eventType, PluginResult result) {
         Log.d(TAG, "emitEvent: " + eventType + " result " + result.toString());
-        ArrayList<CallbackContext> callbackContexts = CordovaCall.getCallbackContexts().get(eventType);
+        ArrayList<CallbackContext> callbackContexts = CordovaCall.getCallbackContexts().computeIfAbsent(eventType, k -> new ArrayList<>());
         if (callbackContexts.size() == 0) {
             Log.d(TAG, "nothing yet listening for CordovaCall event: " + eventType + " enqueuing message for later...");
             HashMap event = new HashMap();
@@ -274,7 +261,7 @@ public class CordovaCall extends CordovaPlugin {
         } else if (action.equals("registerEvent")) {
             String eventType = args.getString(0);
             CallbackContext callbackContext1 = this.callbackContext;
-            ArrayList<CallbackContext> callbackContextList = callbackContextMap.get(eventType);
+            ArrayList<CallbackContext> callbackContextList = callbackContextMap.computeIfAbsent(eventType, k -> new ArrayList<>());
             callbackContextList.add(callbackContext1);
             for (final HashMap event : enqueuedEvents) {
                 if (event.get("eventType").equals(eventType)) {

--- a/src/android/CordovaCall.java
+++ b/src/android/CordovaCall.java
@@ -67,6 +67,8 @@ public class CordovaCall extends CordovaPlugin {
         callbackContextMap.put("reject", new ArrayList<CallbackContext>());
         callbackContextMap.put("mute", new ArrayList<CallbackContext>());
         callbackContextMap.put("unmute", new ArrayList<CallbackContext>());
+        callbackContextMap.put("hold", new ArrayList<CallbackContext>());
+        callbackContextMap.put("unhold", new ArrayList<CallbackContext>());
         callbackContextMap.put("hangup", new ArrayList<CallbackContext>());
         callbackContextMap.put("sendCall", new ArrayList<CallbackContext>());
         callbackContextMap.put("DTMF", new ArrayList<CallbackContext>());


### PR DESCRIPTION
registerEvent (Cordovacall.on(event, fn)) is called liked this, registering listeners.

<img width="1247" height="297" alt="Screenshot from 2026-03-10 20-45-49" src="https://github.com/user-attachments/assets/cf00ef8d-e0df-4b8c-9b23-1d76ff19ae05" />

The inital list of listeners needs to be initialised to an empty array for each of these events.

Fixes this issue:

<img width="1304" height="740" alt="Screenshot from 2026-03-10 20-49-44" src="https://github.com/user-attachments/assets/3d6878d9-cf4b-430b-8d8b-ba67a3d2f4a1" />


