### PR TITLE
CallAudioService: For IncomingCallConnection Start Only Once ACTIVE So that RECORD_AUDIO Permission is Requested/Granted

### DIFF
--- a/src/android/CallConnection.java
+++ b/src/android/CallConnection.java
@@ -48,15 +48,7 @@ class CallConnection extends Connection {
         super.onStateChanged(state);
         Log.d(MyConnectionService.TAG, "connection onStateChanged new state: " + Connection.stateToString(state));
 
-        if (state == Connection.STATE_RINGING || state == Connection.STATE_DIALING) {
-            // NOTE: CallAudioService should be started before mic access, in order to work.
-            // IMPORTANT: This preserves the ability to use the mic when the app is in the background!
-            Log.d(MyConnectionService.TAG, "Starting CallAudioService...");
-            Intent intent = new Intent(service.getApplicationContext(), CallAudioService.class);
-            intent.putExtra("peerName", peerName);
-            intent.putExtra("sessionId", this.sessionId);
-            service.startForegroundService(intent);
-        } else if (state == Connection.STATE_ACTIVE) {
+        if (state == Connection.STATE_ACTIVE) {
             AudioRouteMonitor.onCallConnected();
         } else if (state == Connection.STATE_DISCONNECTED) {
             this.destroy();
@@ -75,5 +67,16 @@ class CallConnection extends Connection {
         intent.putExtra("sessionId", this.sessionId);
         intent.putExtra("state", state);
         LocalBroadcastManager.getInstance(service.getApplicationContext()).sendBroadcast(intent);
+    }
+
+    protected void startCallAudioService() {
+        // NOTE: CallAudioService should be started before mic access, in order to work.
+        // IMPORTANT: This preserves the ability to use the mic when the app is in the background!
+        // IMPORTANT: RECORD_AUDIO permission must be granted beforehand! (since this service is flagged with: FOREGROUND_SERVICE_TYPE_MICROPHONE)
+        Log.d(MyConnectionService.TAG, "Starting CallAudioService...");
+        Intent intent = new Intent(service.getApplicationContext(), CallAudioService.class);
+        intent.putExtra("peerName", peerName);
+        intent.putExtra("sessionId", this.sessionId);
+        service.startForegroundService(intent);
     }
 }

--- a/src/android/IncomingCallConnection.java
+++ b/src/android/IncomingCallConnection.java
@@ -79,7 +79,7 @@ class IncomingCallConnection extends CallConnection {
     @Override
     public void onStateChanged(int state) {
         if (state == Connection.STATE_ACTIVE) {
-            // For an incoming call specifically, we wait for the connection be ACTIVE as this would
+            // For an incoming call specifically, we wait for the connection to be ACTIVE as this would
             // be after the facetalk web app has answered the call + RECORD_AUDIO permission is granted
             this.startCallAudioService();
         } else if (state == Connection.STATE_DISCONNECTED) {

--- a/src/android/IncomingCallConnection.java
+++ b/src/android/IncomingCallConnection.java
@@ -78,7 +78,11 @@ class IncomingCallConnection extends CallConnection {
 
     @Override
     public void onStateChanged(int state) {
-        if (state == Connection.STATE_DISCONNECTED) {
+        if (state == Connection.STATE_ACTIVE) {
+            // For an incoming call specifically, we wait for the connection be ACTIVE as this would
+            // be after the facetalk web app has answered the call + RECORD_AUDIO permission is granted
+            this.startCallAudioService();
+        } else if (state == Connection.STATE_DISCONNECTED) {
             cancelIncomingCallNotification();
         }
 

--- a/src/android/OutgoingCallConnection.java
+++ b/src/android/OutgoingCallConnection.java
@@ -11,7 +11,7 @@ class OutgoingCallConnection extends CallConnection {
     public void onStateChanged(int state) {
         if (state == Connection.STATE_DIALING) {
             // For outgoing connections specifically, permissions are requested (including the necessary RECORD_AUDIO)
-            // before facetalk calls sendCall so when the OutoingCallConnection is created and dialing,
+            // before facetalk calls sendCall so when the OutgoingCallConnection is created and dialing,
             // we can safely proceed to start the call audio service.
             this.startCallAudioService();
         }

--- a/src/android/OutgoingCallConnection.java
+++ b/src/android/OutgoingCallConnection.java
@@ -10,7 +10,7 @@ class OutgoingCallConnection extends CallConnection {
     @Override
     public void onStateChanged(int state) {
         if (state == Connection.STATE_DIALING) {
-            // For outgoing connections specifically, permissions are requested (including the necessaryRECORD_AUDIO)
+            // For outgoing connections specifically, permissions are requested (including the necessary RECORD_AUDIO)
             // before facetalk calls sendCall so when the OutoingCallConnection is created and dialing,
             // we can safely proceed to start the call audio service.
             this.startCallAudioService();

--- a/src/android/OutgoingCallConnection.java
+++ b/src/android/OutgoingCallConnection.java
@@ -1,5 +1,7 @@
 package com.dmarc.cordovacall;
 
+import android.telecom.Connection;
+
 class OutgoingCallConnection extends CallConnection {
     OutgoingCallConnection(MyConnectionService service, String peerName, String sessionId) {
         super(service, peerName, sessionId);
@@ -7,6 +9,12 @@ class OutgoingCallConnection extends CallConnection {
 
     @Override
     public void onStateChanged(int state) {
+        if (state == Connection.STATE_DIALING) {
+            // For outgoing connections specifically, permissions are requested (including the necessaryRECORD_AUDIO)
+            // before facetalk calls sendCall so when the OutoingCallConnection is created and dialing,
+            // we can safely proceed to start the call audio service.
+            this.startCallAudioService();
+        }
         super.onStateChanged(state);
     }
 }


### PR DESCRIPTION
Changes up the logic of **when** we start the CallAudioService to satisify the requirement of only starting the service (which is of type: FOREGROUND_SERVICE_TYPE_MICROPHONE) when RECORD_AUDIO permission is granted beforehand.

Fixes a critical issue causing the app to crash on answering an incoming call:

<img width="1721" height="295" alt="image" src="https://github.com/user-attachments/assets/54347c2b-7580-483e-873e-145a5067cbe2" />


Resolves issue with app crashing when answering a call: https://github.com/iotum/facetalk/issues/11640#issuecomment-4047261997