### PR TITLE
fix dismiss ringing call on iOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-callkit",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "Cordova plugin that lets you use iOS CallKit UI (with PushKit) and Android ConnectionService UI",
   "cordova": {
     "id": "cordova-plugin-callkit",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="cordova-plugin-callkit" version="1.3.8" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="cordova-plugin-callkit" version="1.3.9" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>Cordova CallKit</name>
 
     <js-module name="VoIPPushNotification" src="www/VoIPPushNotification.js">

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -1243,7 +1243,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     }
 
     // Do something if dismiss key is present and true
-    if (payloadDict[@"dismiss"] == nil || payloadDict[@"dismiss"] == false) {
+    if (payloadDict[@"dismiss"] == nil || payloadDict[@"dismiss"] == [NSNull null] || ![payloadDict[@"dismiss"] boolValue]) {
         [self logMessage:@"Dismiss key not found in payload or is false"];
         return;
     } else {

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -926,13 +926,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     NSUUID *callUUID = call[@"callUUID"];
     if (!callUUID) return nil;
 
-    NSArray<CXCall *> *calls = self.callController.callObserver.calls;
-    for (CXCall *call in calls) {
-        if ([call.UUID isEqual:callUUID]) {
-            return call;
-        }
-    }
-    return nil;
+    return [self callForUUID:callUUID];
 }
 
 // Maps the callkit internal callUUID with the facetalk sessionId
@@ -1253,7 +1247,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         [self logMessage:@"Dismiss key not found in payload or is false"];
         return;
     } else {
-        [self _dismissRingingCall:payloadDict[@"call_uuid"]];
+        [self _dismissRingingCall:payloadDict[@"session_id"]];
     }
 }
 


### PR DESCRIPTION
Pass the `session_id` instead of the `call_uuid` to dismiss a ringing call...