### PR TITLE
iOS handle multiple calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-callkit",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "description": "Cordova plugin that lets you use iOS CallKit UI (with PushKit) and Android ConnectionService UI",
   "cordova": {
     "id": "cordova-plugin-callkit",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="cordova-plugin-callkit" version="1.3.9" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="cordova-plugin-callkit" version="1.3.10" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>Cordova CallKit</name>
 
     <js-module name="VoIPPushNotification" src="www/VoIPPushNotification.js">

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -402,13 +402,13 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         CXSetMutedCallAction *muteAction = [[CXSetMutedCallAction alloc] initWithCallUUID:call.UUID muted:YES];
         CXTransaction *transaction = [[CXTransaction alloc] initWithAction:muteAction];
         [self logMessage:[NSString stringWithFormat:@"Programmatically Muting Call: %@", sessionId]];
+        self.activeCalls[sessionId][@"muted"] = @YES; // update this early so the callback does not emit back to facetalk
         [self.callController requestTransaction:transaction completion:^(NSError * _Nullable error) {
             if (error == nil) {
-                self.activeCalls[sessionId][@"muted"] = @YES; // update this early so the callback does not emit back to facetalk
                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Muted Successfully"];
             } else {
                 [self logMessage:@"Error occurred muting Call"];
-                self.activeCalls[sessionId][@"muted"] = @NO;
+                self.activeCalls[sessionId][@"muted"] = @NO; // Revert the muted state if the transaction failed
                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"An error occurred"];
             }
             [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
@@ -428,14 +428,14 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     if (call) {
         CXSetMutedCallAction *unmuteAction = [[CXSetMutedCallAction alloc] initWithCallUUID:call.UUID muted:NO];
         CXTransaction *transaction = [[CXTransaction alloc] initWithAction:unmuteAction];
-        [self logMessage:[NSString stringWithFormat:@"Programatically Unmuting Call: %@", sessionId]];
+        [self logMessage:[NSString stringWithFormat:@"Programmatically Unmuting Call: %@", sessionId]];
+        self.activeCalls[sessionId][@"muted"] = @NO; // update this early so the callback does not emit back to facetalk
         [self.callController requestTransaction:transaction completion:^(NSError * _Nullable error) {
             if (error == nil) {
-                self.activeCalls[sessionId][@"muted"] = @NO; // update this early so the callback does not emit back to facetalk
                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Unmuted Successfully"];
             } else {
                 [self logMessage:@"Error occurred unmuting Call"];
-                self.activeCalls[sessionId][@"muted"] = @YES;
+                self.activeCalls[sessionId][@"muted"] = @YES; // Revert the unmuted state if the transaction failed
                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"An error occurred"];
             }
             [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
@@ -650,13 +650,14 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         CXSetHeldCallAction *holdAction = [[CXSetHeldCallAction alloc] initWithCallUUID:call.UUID onHold:YES];
         CXTransaction *transaction = [[CXTransaction alloc] initWithAction:holdAction];
         [self logMessage:[NSString stringWithFormat:@"Programmatically Holding Call: %@", sessionId]];
+        self.activeCalls[sessionId][@"onHold"] = @YES; // update this early so the callback does not emit back to facetalk
         [self.callController requestTransaction:transaction completion:^(NSError * _Nullable error) {
             if (error == nil) {
-                self.activeCalls[sessionId][@"onHold"] = @YES; // update this early so the callback does not emit back to facetalk
                 NSDictionary *resultDict = @{ @"message": @"hold event called successfully", @"sessionId": sessionId };
                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:resultDict];
             } else {
                 [self logMessage:@"Error occurred holding Call"];
+                self.activeCalls[sessionId][@"onHold"] = @NO; // Revert the onHold state if the transaction failed
                 NSDictionary *resultDict = @{ @"message": @"hold event error", @"sessionId": sessionId };
                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:resultDict];
             }
@@ -679,13 +680,14 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         CXSetHeldCallAction *unholdAction = [[CXSetHeldCallAction alloc] initWithCallUUID:call.UUID onHold:NO];
         CXTransaction *transaction = [[CXTransaction alloc] initWithAction:unholdAction];
         [self logMessage:[NSString stringWithFormat:@"Programmatically Unholding Call: %@", sessionId]];
+        self.activeCalls[sessionId][@"onHold"] = @NO; // update this early so the callback does not emit back to facetalk
         [self.callController requestTransaction:transaction completion:^(NSError * _Nullable error) {
             if (error == nil) {
-                self.activeCalls[sessionId][@"onHold"] = @NO; // update this early so the callback does not emit back to facetalk
                 NSDictionary *resultDict = @{ @"message": @"unhold event called successfully", @"sessionId": sessionId };
                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:resultDict];
             } else {
                 [self logMessage:@"Error occurred unholding Call"];
+                self.activeCalls[sessionId][@"onHold"] = @YES; // Revert the onHold state if the transaction failed
                 NSDictionary *resultDict = @{ @"message": @"unhold event error", @"sessionId": sessionId };
                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:resultDict];
             }

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -401,7 +401,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     if (call) {
         CXSetMutedCallAction *muteAction = [[CXSetMutedCallAction alloc] initWithCallUUID:call.UUID muted:YES];
         CXTransaction *transaction = [[CXTransaction alloc] initWithAction:muteAction];
-        [self logMessage:[NSString stringWithFormat:@"Programatically Muting Call: %@", sessionId]];
+        [self logMessage:[NSString stringWithFormat:@"Programmatically Muting Call: %@", sessionId]];
         [self.callController requestTransaction:transaction completion:^(NSError * _Nullable error) {
             if (error == nil) {
                 self.activeCalls[sessionId][@"muted"] = @YES; // update this early so the callback does not emit back to facetalk

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -37,8 +37,8 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     CXProviderConfiguration *providerConfiguration;
     appName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"];
     providerConfiguration = [[CXProviderConfiguration alloc] initWithLocalizedName:appName];
-    providerConfiguration.maximumCallGroups = 1; // Max simultaneous active calls allowed
-    providerConfiguration.maximumCallsPerCallGroup = 1; // Max calls allowed to be handled at once as a group, including held calls
+    providerConfiguration.maximumCallGroups = 2; // Max calls allowed to be handled at once as a group, including held calls
+    providerConfiguration.maximumCallsPerCallGroup = 5; // Max simultaneous active calls allowed
     NSMutableSet *handleTypes = [[NSMutableSet alloc] init];
     [handleTypes addObject:@(CXHandleTypePhoneNumber)];
     providerConfiguration.supportedHandleTypes = handleTypes;
@@ -100,8 +100,8 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 {
     CXProviderConfiguration *providerConfiguration;
     providerConfiguration = [[CXProviderConfiguration alloc] initWithLocalizedName:appName];
-    providerConfiguration.maximumCallGroups = 1; // Max simultaneous active calls allowed
-    providerConfiguration.maximumCallsPerCallGroup = 1; // Max calls allowed to be handled at once as a group, including held calls
+    providerConfiguration.maximumCallGroups = 2; // Max simultaneous active calls allowed
+    providerConfiguration.maximumCallsPerCallGroup = 5; // Max calls allowed to be handled at once as a group, including held calls
     if(ringtone != nil) {
         providerConfiguration.ringtoneSound = ringtone;
     }
@@ -394,17 +394,17 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 
 - (void)mute:(CDVInvokedUrlCommand*)command
 {
-    [self logMessage:@"mute"];
+    [self logMessage:@"facetalk initiated mute"];
     __block CDVPluginResult* pluginResult = nil;
     NSString* sessionId = [command.arguments objectAtIndex:0];
     CXCall *call = [self callForSessionId:sessionId];
     if (call) {
         CXSetMutedCallAction *muteAction = [[CXSetMutedCallAction alloc] initWithCallUUID:call.UUID muted:YES];
         CXTransaction *transaction = [[CXTransaction alloc] initWithAction:muteAction];
-        [self logMessage:@"Programatically Muting Call"];
+        [self logMessage:[NSString stringWithFormat:@"Programatically Muting Call: %@", sessionId]];
         [self.callController requestTransaction:transaction completion:^(NSError * _Nullable error) {
             if (error == nil) {
-                self.activeCalls[sessionId][@"muted"] = @YES;
+                self.activeCalls[sessionId][@"muted"] = @YES; // update this early so the callback does not emit back to facetalk
                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Muted Successfully"];
             } else {
                 [self logMessage:@"Error occurred muting Call"];
@@ -421,17 +421,17 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 
 - (void)unmute:(CDVInvokedUrlCommand*)command
 {
-    [self logMessage:@"unmute"];
+    [self logMessage:@"facetalk initiated unmute"];
     __block CDVPluginResult* pluginResult = nil;
     NSString* sessionId = [command.arguments objectAtIndex:0];
     CXCall *call = [self callForSessionId:sessionId];
     if (call) {
         CXSetMutedCallAction *unmuteAction = [[CXSetMutedCallAction alloc] initWithCallUUID:call.UUID muted:NO];
         CXTransaction *transaction = [[CXTransaction alloc] initWithAction:unmuteAction];
-        [self logMessage:@"Programatically Unmuting Call"];
+        [self logMessage:[NSString stringWithFormat:@"Programatically Unmuting Call: %@", sessionId]];
         [self.callController requestTransaction:transaction completion:^(NSError * _Nullable error) {
             if (error == nil) {
-                self.activeCalls[sessionId][@"muted"] = @NO;
+                self.activeCalls[sessionId][@"muted"] = @NO; // update this early so the callback does not emit back to facetalk
                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Unmuted Successfully"];
             } else {
                 [self logMessage:@"Error occurred unmuting Call"];
@@ -642,16 +642,17 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 
 - (void)hold:(CDVInvokedUrlCommand*)command
 {
-    [self logMessage:@"hold"];
+    [self logMessage:@"facetalk initiated hold"];
     __block CDVPluginResult* pluginResult = nil;
     NSString* sessionId = [command.arguments objectAtIndex:0];
     CXCall *call = [self callForSessionId:sessionId];
     if (call) {
         CXSetHeldCallAction *holdAction = [[CXSetHeldCallAction alloc] initWithCallUUID:call.UUID onHold:YES];
         CXTransaction *transaction = [[CXTransaction alloc] initWithAction:holdAction];
-        [self logMessage:@"Programatically Holding Call"];
+        [self logMessage:[NSString stringWithFormat:@"Programatically Holding Call: %@", sessionId]];
         [self.callController requestTransaction:transaction completion:^(NSError * _Nullable error) {
             if (error == nil) {
+                self.activeCalls[sessionId][@"onHold"] = @YES; // update this early so the callback does not emit back to facetalk
                 NSDictionary *resultDict = @{ @"message": @"hold event called successfully", @"sessionId": sessionId };
                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:resultDict];
             } else {
@@ -670,16 +671,17 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 
 - (void)unhold:(CDVInvokedUrlCommand*)command
 {
-    [self logMessage:@"unhold"];
+    [self logMessage:@"facetalk initiated unhold"];
     __block CDVPluginResult* pluginResult = nil;
     NSString* sessionId = [command.arguments objectAtIndex:0];
     CXCall *call = [self callForSessionId:sessionId];
     if (call) {
         CXSetHeldCallAction *unholdAction = [[CXSetHeldCallAction alloc] initWithCallUUID:call.UUID onHold:NO];
         CXTransaction *transaction = [[CXTransaction alloc] initWithAction:unholdAction];
-        [self logMessage:@"Programatically Unholding Call"];
+        [self logMessage:[NSString stringWithFormat:@"Programatically Unholding Call: %@", sessionId]];
         [self.callController requestTransaction:transaction completion:^(NSError * _Nullable error) {
             if (error == nil) {
+                self.activeCalls[sessionId][@"onHold"] = @NO; // update this early so the callback does not emit back to facetalk
                 NSDictionary *resultDict = @{ @"message": @"unhold event called successfully", @"sessionId": sessionId };
                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:resultDict];
             } else {
@@ -818,15 +820,17 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 {
     BOOL isMuted = action.muted;
     NSString *sessionId = [self sessionIdForUUID:action.callUUID];
-    [self logMessage:[NSString stringWithFormat:@"Callkit UI received %@ event, currently %@", isMuted ? @"mute" : @"unmute", [self.activeCalls[sessionId][@"muted"] boolValue] ? @"muted" : @"unmuted"]];
-    [action fulfill];
+    [self logMessage:[NSString stringWithFormat:@"Callkit UI received %@ event, currently %@, sessionId: %@", isMuted ? @"mute" : @"unmute", [self.activeCalls[sessionId][@"muted"] boolValue] ? @"muted" : @"unmuted", sessionId]];
 
     // Ignore the duplicate mute/unmute events, somehow 2 events get sent for every action
     if ([self.activeCalls[sessionId][@"muted"] boolValue] == isMuted) {
         [self logMessage:[NSString stringWithFormat:@"Ignoring duplicate %@ event.", isMuted ? @"mute" : @"unmute"]];
+        [action fulfill];
         return;
     }
     self.activeCalls[sessionId][@"muted"] = @(isMuted); // Update the internal state with the new value
+    [action fulfill];
+
     for (id callbackId in callbackIds[isMuted?@"mute":@"unmute"]) {
         [self logMessage:[NSString stringWithFormat:@"Sending %@ event to JS", isMuted ? @"mute" : @"unmute"]];
         CDVPluginResult* pluginResult = nil;
@@ -853,18 +857,19 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 
 - (void)provider:(CXProvider *)provider performSetHeldCallAction:(CXSetHeldCallAction *)action
 {
-    [self logMessage:@"performSetHeldCallAction"];
     NSString *sessionId = [self sessionIdForUUID:action.callUUID];
-    [self logMessage:[NSString stringWithFormat:@"Callkit UI received %@ event", action.onHold ? @"hold" : @"unhold"]];
+    CXCall *call = [self callForUUID:action.callUUID];
     BOOL isOnHold = action.onHold;
-    [action fulfill];
+    [self logMessage:[NSString stringWithFormat:@"Callkit UI received %@ event, currently %@, sessionId: %@", isOnHold ? @"hold" : @"unhold", [call isOnHold] ? @"on hold" : @"not on hold", sessionId]];
 
     // Ignore the duplicate hold/unhold events to prevent feedback loops
-    CXCall *call = [self callForUUID:action.callUUID];
-    if ([call isOnHold] == isOnHold) {
+    if ([self.activeCalls[sessionId][@"onHold"] boolValue] == isOnHold) {
         [self logMessage:[NSString stringWithFormat:@"Ignoring duplicate %@ event.", isOnHold ? @"hold" : @"unhold"]];
+        [action fulfill];
         return;
     }
+    self.activeCalls[sessionId][@"onHold"] = @(isOnHold); // Update the internal state with the new value
+    [action fulfill];
     for (id callbackId in callbackIds[isOnHold?@"hold":@"unhold"]) {
         CDVPluginResult* pluginResult = nil;
         NSDictionary *resultDict = @{ @"message": [NSString stringWithFormat:@"%@ event called successfully", isOnHold ? @"hold" : @"unhold"], @"sessionId": sessionId };

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -867,7 +867,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     NSString *sessionId = [self sessionIdForUUID:action.callUUID];
     CXCall *call = [self callForUUID:action.callUUID];
     BOOL isOnHold = action.onHold;
-    [self logMessage:[NSString stringWithFormat:@"Callkit UI received %@ event, currently %@, sessionId: %@", isOnHold ? @"hold" : @"unhold", [call isOnHold] ? @"on hold" : @"not on hold", sessionId]];
+    [self logMessage:[NSString stringWithFormat:@"Callkit UI received %@ event, we say: %@, callkit says: %@, sessionId: %@", isOnHold ? @"hold" : @"unhold", [self.activeCalls[sessionId][@"onHold"] boolValue] ? @"on hold" : @"not on hold", [call isOnHold] ? @"on hold" : @"not on hold", sessionId]];
     if (!sessionId) {
         [self logMessage:[NSString stringWithFormat:@"performSetHeldCallAction: no sessionId found for callUUID %@, ignoring %@ event", action.callUUID.UUIDString, isOnHold ? @"hold" : @"unhold"]];
         [action fulfill];

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -822,6 +822,11 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 {
     BOOL isMuted = action.muted;
     NSString *sessionId = [self sessionIdForUUID:action.callUUID];
+    if (!sessionId) {
+        [self logMessage:[NSString stringWithFormat:@"performSetMutedCallAction: no sessionId found for callUUID %@, ignoring %@ event", action.callUUID.UUIDString, isMuted ? @"mute" : @"unmute"]];
+        [action fulfill];
+        return;
+    }
     [self logMessage:[NSString stringWithFormat:@"Callkit UI received %@ event, currently %@, sessionId: %@", isMuted ? @"mute" : @"unmute", [self.activeCalls[sessionId][@"muted"] boolValue] ? @"muted" : @"unmuted", sessionId]];
 
     // Ignore the duplicate mute/unmute events, somehow 2 events get sent for every action
@@ -863,7 +868,11 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     CXCall *call = [self callForUUID:action.callUUID];
     BOOL isOnHold = action.onHold;
     [self logMessage:[NSString stringWithFormat:@"Callkit UI received %@ event, currently %@, sessionId: %@", isOnHold ? @"hold" : @"unhold", [call isOnHold] ? @"on hold" : @"not on hold", sessionId]];
-
+    if (!sessionId) {
+        [self logMessage:[NSString stringWithFormat:@"performSetHeldCallAction: no sessionId found for callUUID %@, ignoring %@ event", action.callUUID.UUIDString, isOnHold ? @"hold" : @"unhold"]];
+        [action fulfill];
+        return;
+    }
     // Ignore the duplicate hold/unhold events to prevent feedback loops
     if ([self.activeCalls[sessionId][@"onHold"] boolValue] == isOnHold) {
         [self logMessage:[NSString stringWithFormat:@"Ignoring duplicate %@ event.", isOnHold ? @"hold" : @"unhold"]];

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -649,7 +649,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     if (call) {
         CXSetHeldCallAction *holdAction = [[CXSetHeldCallAction alloc] initWithCallUUID:call.UUID onHold:YES];
         CXTransaction *transaction = [[CXTransaction alloc] initWithAction:holdAction];
-        [self logMessage:[NSString stringWithFormat:@"Programatically Holding Call: %@", sessionId]];
+        [self logMessage:[NSString stringWithFormat:@"Programmatically Holding Call: %@", sessionId]];
         [self.callController requestTransaction:transaction completion:^(NSError * _Nullable error) {
             if (error == nil) {
                 self.activeCalls[sessionId][@"onHold"] = @YES; // update this early so the callback does not emit back to facetalk
@@ -678,7 +678,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     if (call) {
         CXSetHeldCallAction *unholdAction = [[CXSetHeldCallAction alloc] initWithCallUUID:call.UUID onHold:NO];
         CXTransaction *transaction = [[CXTransaction alloc] initWithAction:unholdAction];
-        [self logMessage:[NSString stringWithFormat:@"Programatically Unholding Call: %@", sessionId]];
+        [self logMessage:[NSString stringWithFormat:@"Programmatically Unholding Call: %@", sessionId]];
         [self.callController requestTransaction:transaction completion:^(NSError * _Nullable error) {
             if (error == nil) {
                 self.activeCalls[sessionId][@"onHold"] = @NO; // update this early so the callback does not emit back to facetalk


### PR DESCRIPTION
Theoretically implementing multiple calls is just modifying `providerConfiguration.maximumCallGroups` to be more than 1, this will allow the callkit UI to prompt for "hold and accept" for the second call.

Implemented:
- Send through `sessionId` when mute/unmute via callkit UI

Fixes:
- Improve logging with more details
- Improve comments
- do `[action fulfill];` only after we update the value internally in our mapping
   - so hopefully subsequent callbacks will be queued until after we're done processing the first callback
- track hold state ourselves as native callkit has a delay between calling programatic hold and it being set natively
   - needed to prevent a feedback loop

Note:
- Callkit does multiple calls by holding or ending the current call before connecting.
- Callkit can only have 1 call on hold at a time. A third call will only prompt to end the current call or held call before answering.