### PR TITLE
fix build failure

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -100,7 +100,6 @@
         <podspec>
             <pods use-frameworks="true">
                 <pod name="SocketRocket" spec="0.7.0" />
-                <pod name="GoogleWebRTC" />
             </pods>
         </podspec>
     </platform>


### PR DESCRIPTION
[19:11:31]: $ set -o pipefail && xcodebuild -workspace platforms/ios/Callbridge\ Rocks.xcworkspace -scheme Callbridge\ Rocks -configuration Debug -destination 'generic/platform=iOS' -archivePath /Users/rexchiu/Library/Developer/Xcode/Archives/2026-03-19/callbridge.rocks\ 2026-03-19\ 19.11.31.xcarchive -allowProvisioningUpdates archive | tee /Users/rexchiu/Library/Logs/gym/Callbridge\ Rocks-Callbridge\ Rocks.log | xcpretty
[19:11:36]: ▸ ❌  error: Multiple commands produce '/Users/rexchiu/Library/Developer/Xcode/DerivedData/Callbridge_Rocks-fgqavfqfzfhsgadoehsrsqligtri/Build/Intermediates.noindex/ArchiveIntermediates/Callbridge Rocks/InstallationBuildProductsLocation/Applications/Callbridge Rocks.app/Frameworks/WebRTC.framework'
[19:11:36]: ▸     duplicate output file '/Users/rexchiu/Library/Developer/Xcode/DerivedData/Callbridge_Rocks-fgqavfqfzfhsgadoehsrsqligtri/Build/Intermediates.noindex/ArchiveIntermediates/Callbridge Rocks/InstallationBuildProductsLocation/Applications/Callbridge Rocks.app/Frameworks/WebRTC.framework' on task: PhaseScriptExecution [CP] Embed Pods Frameworks /Users/rexchiu/Library/Developer/Xcode/DerivedData/Callbridge_Rocks-fgqavfqfzfhsgadoehsrsqligtri/Build/Intermediates.noindex/ArchiveIntermediates/Callbridge Rocks/IntermediateBuildFilesPath/Callbridge Rocks.build/Debug-iphoneos/Callbridge Rocks.build/Script-BDE9EAFD5E9920E0D1667BCC.sh (in target 'Callbridge Rocks' from project 'Callbridge Rocks')
