### PR TITLE
disable iOS hold/unhold/multicall via config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-callkit",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "description": "Cordova plugin that lets you use iOS CallKit UI (with PushKit) and Android ConnectionService UI",
   "cordova": {
     "id": "cordova-plugin-callkit",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="cordova-plugin-callkit" version="1.3.11" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="cordova-plugin-callkit" version="1.3.12" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>Cordova CallKit</name>
 
     <js-module name="VoIPPushNotification" src="www/VoIPPushNotification.js">

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -38,8 +38,8 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     CXProviderConfiguration *providerConfiguration;
     appName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"];
     providerConfiguration = [[CXProviderConfiguration alloc] initWithLocalizedName:appName];
-    providerConfiguration.maximumCallGroups = 2; // Max calls allowed to be handled at once as a group, including held calls
-    providerConfiguration.maximumCallsPerCallGroup = 5; // Max simultaneous active calls allowed
+    providerConfiguration.maximumCallGroups = 1; // Max calls allowed to be handled at once as a group, including held calls
+    providerConfiguration.maximumCallsPerCallGroup = 1; // Max simultaneous active calls allowed
     NSMutableSet *handleTypes = [[NSMutableSet alloc] init];
     [handleTypes addObject:@(CXHandleTypePhoneNumber)];
     providerConfiguration.supportedHandleTypes = handleTypes;
@@ -101,8 +101,8 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 {
     CXProviderConfiguration *providerConfiguration;
     providerConfiguration = [[CXProviderConfiguration alloc] initWithLocalizedName:appName];
-    providerConfiguration.maximumCallGroups = 2; // Max simultaneous active calls allowed
-    providerConfiguration.maximumCallsPerCallGroup = 5; // Max calls allowed to be handled at once as a group, including held calls
+    providerConfiguration.maximumCallGroups = 1; // Max simultaneous active calls allowed
+    providerConfiguration.maximumCallsPerCallGroup = 1; // Max calls allowed to be handled at once as a group, including held calls
     if(ringtone != nil) {
         providerConfiguration.ringtoneSound = ringtone;
     }
@@ -251,7 +251,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         callUpdate.localizedCallerName = callName;
         callUpdate.supportsGrouping = NO;
         callUpdate.supportsUngrouping = NO;
-        callUpdate.supportsHolding = YES;
+        callUpdate.supportsHolding = NO;
         callUpdate.supportsDTMF = enableDTMF;
         [self.provider reportNewIncomingCallWithUUID:callUUID update:callUpdate completion:^(NSError * _Nullable error) {
             if(error == nil) {
@@ -323,7 +323,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         callUpdate.hasVideo = hasVideo;
         callUpdate.supportsGrouping = NO;
         callUpdate.supportsUngrouping = NO;
-        callUpdate.supportsHolding = YES;
+        callUpdate.supportsHolding = NO;
         callUpdate.supportsDTMF = enableDTMF;
         
         [self.provider reportCallWithUUID:call.UUID updated:callUpdate];
@@ -716,7 +716,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     callUpdate.localizedCallerName = action.contactIdentifier;
     callUpdate.supportsGrouping = NO;
     callUpdate.supportsUngrouping = NO;
-    callUpdate.supportsHolding = YES;
+    callUpdate.supportsHolding = NO;
     callUpdate.supportsDTMF = enableDTMF;
 
     [self.provider reportCallWithUUID:action.callUUID updated:callUpdate];


### PR DESCRIPTION
iOS unhold doesn't play audio after unhold with/without callkit, it needs to be fixed before we can deploy this feature.

This config change will hide the callkit hold/unhold button, and not prompt users to "hold + accept" a call.

It doesn't change the facetalk -> callkit hold/unhold implementation, and it will still flow and emit all of the callbacks/etc, though with the same final state of no audio out after unhold.