### PR TITLE
iOS guard against malformed VOIP push notification payloads and not have our app killed

### DIFF
--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -925,6 +925,17 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 }
 
 // Internal method that can be called from within the plugin
+// iOS 13+ requires reportNewIncomingCallWithUUID before returning from a VoIP push, or the app is killed.
+// Call this when the push payload is malformed and we have nothing real to report.
+- (void)_reportAndEndDummyCall {
+    NSUUID *dummyUUID = [[NSUUID alloc] init];
+    CXCallUpdate *callUpdate = [[CXCallUpdate alloc] init];
+    callUpdate.remoteHandle = [[CXHandle alloc] initWithType:CXHandleTypePhoneNumber value:@"unknown"];
+    [self.provider reportNewIncomingCallWithUUID:dummyUUID update:callUpdate completion:^(NSError *reportError) {
+        [self.provider reportCallWithUUID:dummyUUID endedAtDate:nil reason:CXCallEndedReasonFailed];
+    }];
+}
+
 - (BOOL)_dismissRingingCall:(NSString *)sessionId {
     [self logMessage:@"_dismissRingingCall"];
 
@@ -1203,10 +1214,18 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     NSDictionary *payloadObj = [NSJSONSerialization JSONObjectWithData:payloadJsonData options:0 error:&error];
     if (error || ![payloadObj isKindOfClass:[NSDictionary class]]) {
         [self logMessage:[NSString stringWithFormat:@"Error parsing payload JSON: %@", error]];
+        [self _reportAndEndDummyCall];
+        completion();
         return;
     }
     // session_id param is the parsed call_uuid for NS PBX calls, it's session_id = callId + ftag, where call_uuid = callId;ftag;ttag
     NSString *sessionId = [payloadObj valueForKey:@"session_id"] ?: [payloadObj valueForKey:@"call_uuid"];
+    if (!sessionId) {
+        [self logMessage:@"didReceiveIncomingPush: payload missing session_id and call_uuid, ignoring"];
+        [self _reportAndEndDummyCall];
+        completion();
+        return;
+    }
     NSArray* args = [NSArray arrayWithObjects:[payloadObj valueForKey:@"from"], [NSNull null], sessionId, nil];
     CDVInvokedUrlCommand* newCommand = [[CDVInvokedUrlCommand alloc] initWithArguments:args callbackId:@"" className:self.VoIPPushClassName methodName:self.VoIPPushMethodName];
 

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -1214,20 +1214,24 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         completion();
         return;
     }
-    // session_id param is the parsed call_uuid for NS PBX calls, it's session_id = callId + ftag, where call_uuid = callId;ftag;ttag
-    NSString *sessionId = [payloadObj valueForKey:@"session_id"] ?: [payloadObj valueForKey:@"call_uuid"];
-    if (sessionId == nil) {
-        [self logMessage:@"didReceiveIncomingPush: payload missing session_id and call_uuid, cannot process call"];
+    // Validate all required string fields in the parsed payload
+    NSString *validationError = nil;
+    if (![self _validatePayload:payloadObj error:&validationError]) {
+        [self logMessage:[NSString stringWithFormat:@"didReceiveIncomingPush: invalid payload - %@", validationError]];
         [self _reportAndEndDummyCall];
         completion();
         return;
     }
-    NSArray* args = [NSArray arrayWithObjects:[payloadObj valueForKey:@"from"], [NSNull null], sessionId, nil];
+
+    // session_id param is the parsed call_uuid for NS PBX calls, it's session_id = callId + ftag, where call_uuid = callId;ftag;ttag
+    NSString *sessionId = payloadObj[@"session_id"] ?: payloadObj[@"call_uuid"];
+    NSString *fromId = payloadObj[@"from"];
+    NSArray* args = [NSArray arrayWithObjects:fromId ?: [NSNull null], [NSNull null], sessionId, nil];
     CDVInvokedUrlCommand* newCommand = [[CDVInvokedUrlCommand alloc] initWithArguments:args callbackId:@"" className:self.VoIPPushClassName methodName:self.VoIPPushMethodName];
 
     // Store URL and Call Id so they can be used for call Answer/Reject
-    callBackUrl = [payloadObj valueForKey:@"callback_url"];
-    NSString *Type = [payloadObj valueForKey:@"type"];
+    callBackUrl = payloadObj[@"callback_url"];
+    NSString *Type = payloadObj[@"type"] ?: @"";
     hasVideo = ![Type isEqualToString:@"incoming_phone_call"];
     self.activeCalls[sessionId] = [@{
         @"callData": [[NSString alloc] initWithData:payloadJsonData encoding:NSUTF8StringEncoding],
@@ -1295,6 +1299,42 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     } else {
         [self _dismissRingingCall:payloadDict[@"session_id"]];
     }
+}
+
+// Validates that all required fields in a parsed VoIP push payload are non-empty NSStrings.
+// Optional fields (type, callback_url, from) are allowed to be absent but must be NSString if present.
+// Returns NO and sets error to a description of the first invalid field found.
+- (BOOL)_validatePayload:(NSDictionary *)payload error:(NSString **)error
+{
+    // Required: at least one of session_id or call_uuid must be a non-empty NSString
+    NSArray *sessionKeys = @[@"session_id", @"call_uuid"];
+    BOOL hasSessionId = NO;
+    for (NSString *key in sessionKeys) {
+        id val = payload[key];
+        if (val != nil && val != [NSNull null]) {
+            if (![val isKindOfClass:[NSString class]] || [(NSString *)val length] == 0) {
+                if (error) *error = [NSString stringWithFormat:@"'%@' is not a non-empty string", key];
+                return NO;
+            }
+            hasSessionId = YES;
+        }
+    }
+    if (!hasSessionId) {
+        if (error) *error = @"missing session_id and call_uuid";
+        return NO;
+    }
+
+    // Optional string fields — must be NSString if present
+    NSArray *optionalStringKeys = @[@"from", @"type", @"callback_url"];
+    for (NSString *key in optionalStringKeys) {
+        id val = payload[key];
+        if (val != nil && val != [NSNull null] && ![val isKindOfClass:[NSString class]]) {
+            if (error) *error = [NSString stringWithFormat:@"'%@' is present but not a string", key];
+            return NO;
+        }
+    }
+
+    return YES;
 }
 
 // iOS 13+ requires reportNewIncomingCallWithUUID: to be called on every VoIP push, even

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -925,17 +925,6 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 }
 
 // Internal method that can be called from within the plugin
-// iOS 13+ requires reportNewIncomingCallWithUUID before returning from a VoIP push, or the app is killed.
-// Call this when the push payload is malformed and we have nothing real to report.
-- (void)_reportAndEndDummyCall {
-    NSUUID *dummyUUID = [[NSUUID alloc] init];
-    CXCallUpdate *callUpdate = [[CXCallUpdate alloc] init];
-    callUpdate.remoteHandle = [[CXHandle alloc] initWithType:CXHandleTypePhoneNumber value:@"unknown"];
-    [self.provider reportNewIncomingCallWithUUID:dummyUUID update:callUpdate completion:^(NSError *reportError) {
-        [self.provider reportCallWithUUID:dummyUUID endedAtDate:nil reason:CXCallEndedReasonFailed];
-    }];
-}
-
 - (BOOL)_dismissRingingCall:(NSString *)sessionId {
     [self logMessage:@"_dismissRingingCall"];
 
@@ -1210,7 +1199,14 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     [results setObject:@"" forKey:@"extra"];
 
     NSError *error = nil;
-    NSData *payloadJsonData = [[data objectForKey:@"payload"] dataUsingEncoding:NSUTF8StringEncoding];
+    NSString *payloadString = [data objectForKey:@"payload"];
+    if (![payloadString isKindOfClass:[NSString class]] || payloadString.length == 0) {
+        [self logMessage:@"didReceiveIncomingPush: missing or invalid payload string"];
+        [self _reportAndEndDummyCall];
+        completion();
+        return;
+    }
+    NSData *payloadJsonData = [payloadString dataUsingEncoding:NSUTF8StringEncoding];
     NSDictionary *payloadObj = [NSJSONSerialization JSONObjectWithData:payloadJsonData options:0 error:&error];
     if (error || ![payloadObj isKindOfClass:[NSDictionary class]]) {
         [self logMessage:[NSString stringWithFormat:@"Error parsing payload JSON: %@", error]];
@@ -1220,8 +1216,8 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     }
     // session_id param is the parsed call_uuid for NS PBX calls, it's session_id = callId + ftag, where call_uuid = callId;ftag;ttag
     NSString *sessionId = [payloadObj valueForKey:@"session_id"] ?: [payloadObj valueForKey:@"call_uuid"];
-    if (!sessionId) {
-        [self logMessage:@"didReceiveIncomingPush: payload missing session_id and call_uuid, ignoring"];
+    if (sessionId == nil) {
+        [self logMessage:@"didReceiveIncomingPush: payload missing session_id and call_uuid, cannot process call"];
         [self _reportAndEndDummyCall];
         completion();
         return;
@@ -1299,6 +1295,21 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     } else {
         [self _dismissRingingCall:payloadDict[@"session_id"]];
     }
+}
+
+// iOS 13+ requires reportNewIncomingCallWithUUID: to be called on every VoIP push, even
+// when the payload is malformed. This helper reports a call and immediately ends it so
+// the OS does not penalise the app for ignoring the push.
+- (void)_reportAndEndDummyCall
+{
+    NSUUID *dummyUUID = [[NSUUID alloc] init];
+    CXCallUpdate *update = [[CXCallUpdate alloc] init];
+    update.remoteHandle = [[CXHandle alloc] initWithType:CXHandleTypePhoneNumber value:@"unknown"];
+    update.localizedCallerName = @"Unknown";
+    [self.provider reportNewIncomingCallWithUUID:dummyUUID update:update completion:^(NSError *reportError) {
+        [self logMessage:[NSString stringWithFormat:@"_reportAndEndDummyCall: reported (error: %@)", reportError]];
+        [self.provider reportCallWithUUID:dummyUUID endedAtDate:nil reason:CXCallEndedReasonFailed];
+    }];
 }
 
 - (void)logMessage:(NSString *)message


### PR DESCRIPTION
When we receive a malformed VOIP push notification, we error but then don't properly handle the call which iOS will kill our app for.