### PR TITLE
guard against malformed payloads for iOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-callkit",
-  "version": "1.3.17",
+  "version": "1.3.18",
   "description": "Cordova plugin that lets you use iOS CallKit UI (with PushKit) and Android ConnectionService UI",
   "cordova": {
     "id": "cordova-plugin-callkit",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="cordova-plugin-callkit" version="1.3.17" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="cordova-plugin-callkit" version="1.3.18" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>Cordova CallKit</name>
 
     <js-module name="VoIPPushNotification" src="www/VoIPPushNotification.js">

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -1205,8 +1205,10 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 {
     [self logMessage:[NSString stringWithFormat:@"didReceiveIncomingPush: %@", payload]];
     // apsDict and apsMessage seems to be unused
-    NSDictionary *apsDict = payload.dictionaryPayload[@"aps"] ?: @{};
-    NSString *apsMessage = apsDict[@"alert"] ?: @"";
+    id apsValue = payload.dictionaryPayload[@"aps"];
+    NSDictionary *apsDict = [apsValue isKindOfClass:[NSDictionary class]] ? apsValue : @{};
+    id alertValue = apsDict[@"alert"];
+    NSString *apsMessage = [alertValue isKindOfClass:[NSString class]] ? alertValue : @"";
 
     NSDictionary *data = payload.dictionaryPayload[@"data"];
     [self logMessage:[NSString stringWithFormat:@"received data: %@", data]];

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -936,6 +936,21 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     return NO;
 }
 
+// Reports a dummy incoming call with a random UUID and immediately ends it.
+// Must be called when a VoIP push is received but the payload is malformed,
+// because iOS 13+ will terminate the app if no call is reported.
+- (void)_reportAndEndDummyCall {
+    [self logMessage:@"_reportAndEndDummyCall: reporting dummy call for malformed VoIP push"];
+    NSUUID *dummyUUID = [[NSUUID alloc] init];
+    CXHandle *handle = [[CXHandle alloc] initWithType:CXHandleTypePhoneNumber value:@"unknown"];
+    CXCallUpdate *callUpdate = [[CXCallUpdate alloc] init];
+    callUpdate.remoteHandle = handle;
+    callUpdate.localizedCallerName = @"Unknown";
+    [self.provider reportNewIncomingCallWithUUID:dummyUUID update:callUpdate completion:^(NSError * _Nullable error) {
+        [self.provider reportCallWithUUID:dummyUUID endedAtDate:nil reason:CXCallEndedReasonFailed];
+    }];
+}
+
 // Returns the Callkit CXCall instance for a CallUUID
 - (CXCall *)callForUUID:(NSUUID *)callUUID {
     if (!callUUID) return nil;
@@ -1185,28 +1200,50 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 - (void)pushRegistry:(PKPushRegistry *)registry didReceiveIncomingPushWithPayload:(PKPushPayload *)payload forType:(PKPushType)type withCompletionHandler:(void (^)(void))completion
 {
     [self logMessage:[NSString stringWithFormat:@"didReceiveIncomingPush: %@", payload]];
-    NSDictionary *payloadDict = payload.dictionaryPayload[@"aps"];
-    [self logMessage:[NSString stringWithFormat:@"didReceiveIncomingPushWithPayload: %@", payloadDict]];
-
-    NSString *message = payloadDict[@"alert"];
-    [self logMessage:[NSString stringWithFormat:@"received VoIP message: %@", message]];
+    // apsDict and apsMessage seems to be unused
+    NSDictionary *apsDict = payload.dictionaryPayload[@"aps"] ?: @{};
+    NSString *apsMessage = apsDict[@"alert"] ?: @"";
 
     NSDictionary *data = payload.dictionaryPayload[@"data"];
     [self logMessage:[NSString stringWithFormat:@"received data: %@", data]];
 
+    // guard against empty, nil, or non-dictionary data payload
+    if (!data || ![data isKindOfClass:[NSDictionary class]] || data.count == 0) {
+        [self logMessage:@"didReceiveIncomingPush: data is empty, discarding as dummy call"];
+        [self _reportAndEndDummyCall];
+        completion();
+        return;
+    }
+
+    NSString *payloadString = data[@"payload"];
+    if (!payloadString || payloadString.length == 0) {
+        [self logMessage:@"didReceiveIncomingPush: data has no payload key, discarding as dummy call"];
+        [self _reportAndEndDummyCall];
+        completion();
+        return;
+    }
+
     NSMutableDictionary* results = [NSMutableDictionary dictionaryWithCapacity:2];
-    [results setObject:message forKey:@"function"];
+    [results setObject:apsMessage forKey:@"function"];
     [results setObject:@"" forKey:@"extra"];
 
     NSError *error = nil;
-    NSData *payloadJsonData = [[data objectForKey:@"payload"] dataUsingEncoding:NSUTF8StringEncoding];
+    NSData *payloadJsonData = [payloadString dataUsingEncoding:NSUTF8StringEncoding];
     NSDictionary *payloadObj = [NSJSONSerialization JSONObjectWithData:payloadJsonData options:0 error:&error];
     if (error || ![payloadObj isKindOfClass:[NSDictionary class]]) {
         [self logMessage:[NSString stringWithFormat:@"Error parsing payload JSON: %@", error]];
+        [self _reportAndEndDummyCall];
+        completion();
         return;
     }
     // session_id param is the parsed call_uuid for NS PBX calls, it's session_id = callId + ftag, where call_uuid = callId;ftag;ttag
     NSString *sessionId = [payloadObj valueForKey:@"session_id"] ?: [payloadObj valueForKey:@"call_uuid"];
+    if (!sessionId || sessionId.length == 0) {
+        [self logMessage:@"didReceiveIncomingPush: no session_id or call_uuid (deprecated) in payload, discarding as dummy call"];
+        [self _reportAndEndDummyCall];
+        completion();
+        return;
+    }
     NSArray* args = [NSArray arrayWithObjects:[payloadObj valueForKey:@"from"], [NSNull null], sessionId, nil];
     CDVInvokedUrlCommand* newCommand = [[CDVInvokedUrlCommand alloc] initWithArguments:args callbackId:@"" className:self.VoIPPushClassName methodName:self.VoIPPushMethodName];
 

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -1222,7 +1222,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     }
 
     NSString *payloadString = data[@"payload"];
-    if (!payloadString || payloadString.length == 0) {
+    if (![payloadString isKindOfClass:[NSString class]] || payloadString.length == 0) {
         [self logMessage:@"didReceiveIncomingPush: data has no payload key, discarding as dummy call"];
         [self _reportAndEndDummyCall];
         completion();
@@ -1243,14 +1243,17 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         return;
     }
     // session_id param is the parsed call_uuid for NS PBX calls, it's session_id = callId + ftag, where call_uuid = callId;ftag;ttag
-    NSString *sessionId = [payloadObj valueForKey:@"session_id"] ?: [payloadObj valueForKey:@"call_uuid"];
+    id sessionIdValue = [payloadObj valueForKey:@"session_id"] ?: [payloadObj valueForKey:@"call_uuid"];
+    NSString *sessionId = [sessionIdValue isKindOfClass:[NSString class]] ? sessionIdValue : nil;
     if (!sessionId || sessionId.length == 0) {
         [self logMessage:@"didReceiveIncomingPush: no session_id or call_uuid (deprecated) in payload, discarding as dummy call"];
         [self _reportAndEndDummyCall];
         completion();
         return;
     }
-    NSArray* args = [NSArray arrayWithObjects:[payloadObj valueForKey:@"from"], [NSNull null], sessionId, nil];
+    id fromValue = [payloadObj valueForKey:@"from"];
+    NSString *from = [fromValue isKindOfClass:[NSString class]] ? fromValue : @"Unknown";
+    NSArray* args = [NSArray arrayWithObjects:from, [NSNull null], sessionId, nil];
     CDVInvokedUrlCommand* newCommand = [[CDVInvokedUrlCommand alloc] initWithArguments:args callbackId:@"" className:self.VoIPPushClassName methodName:self.VoIPPushMethodName];
 
     // Store URL and Call Id so they can be used for call Answer/Reject

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -947,6 +947,10 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     callUpdate.remoteHandle = handle;
     callUpdate.localizedCallerName = @"Unknown";
     [self.provider reportNewIncomingCallWithUUID:dummyUUID update:callUpdate completion:^(NSError * _Nullable error) {
+        if (error != nil) {
+            [self logMessage:[NSString stringWithFormat:@"_reportAndEndDummyCall: failed to report dummy incoming call: %@", error.localizedDescription]];
+            return;
+        }
         [self.provider reportCallWithUUID:dummyUUID endedAtDate:nil reason:CXCallEndedReasonFailed];
     }];
 }


### PR DESCRIPTION
Add guards against malformed data in the VOIP notification payload.
- Set default empty values for non-essential values
- Add an explicit check for mandatory values, report as an invalid call before exiting

iOS requires us to always report a call for every VOIP push notification received.
Even if the call is invalid, we must still create a dumy call and mark it as a failed call.

If we don't then iOS will kill the app, and if happening often then the app will stop receiving VOIP push notifications.

QoL: removed some excess legacy logging