### PR TITLE
add a filter for out of order mute/unmute events, and misc changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-callkit",
-  "version": "1.3.19",
+  "version": "1.3.20",
   "description": "Cordova plugin that lets you use iOS CallKit UI (with PushKit) and Android ConnectionService UI",
   "cordova": {
     "id": "cordova-plugin-callkit",

--- a/plugin.xml
+++ b/plugin.xml
@@ -98,6 +98,7 @@
         <framework src="PushKit.framework" />
         <framework src="CallKit.framework" />
         <podspec>
+            <config></config>
             <pods use-frameworks="true">
                 <pod name="SocketRocket" spec="0.7.0" />
             </pods>

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="cordova-plugin-callkit" version="1.3.19" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="cordova-plugin-callkit" version="1.3.20" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>Cordova CallKit</name>
 
     <js-module name="VoIPPushNotification" src="www/VoIPPushNotification.js">

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -125,18 +125,18 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 - (void)setupAudioSession
 {
     @try {
-      AVAudioSession *sessionInstance = [AVAudioSession sharedInstance];
-      [sessionInstance setCategory:AVAudioSessionCategoryPlayAndRecord error:nil];
-      [sessionInstance setMode:AVAudioSessionModeVoiceChat error:nil];
-      NSTimeInterval bufferDuration = .005;
-      [sessionInstance setPreferredIOBufferDuration:bufferDuration error:nil];
-      [sessionInstance setPreferredSampleRate:44100 error:nil];
-      [self logMessage:@"Configuring Audio"];
+        AVAudioSession *sessionInstance = [AVAudioSession sharedInstance];
+        [sessionInstance setCategory:AVAudioSessionCategoryPlayAndRecord
+                         withOptions:AVAudioSessionCategoryOptionMixWithOthers
+                                    | AVAudioSessionCategoryOptionAllowBluetooth
+                                    | AVAudioSessionCategoryOptionAllowAirPlay
+                                    | AVAudioSessionCategoryOptionAllowBluetoothA2DP
+                               error:nil];
+        [sessionInstance setMode:AVAudioSessionModeVoiceChat error:nil];
     }
     @catch (NSException *exception) {
-      [self logMessage:@"Unknown error returned from setupAudioSession"];
+        [self logMessage:@"Unknown error returned from setupAudioSession"];
     }
-    return;
 }
 
 - (void)setAppName:(CDVInvokedUrlCommand*)command
@@ -325,15 +325,6 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     if(call && !call.hasConnected) {
         [self.provider reportOutgoingCallWithUUID:call.UUID connectedAtDate:nil];
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Call connected successfully"];
-
-        CXCallUpdate *callUpdate = [[CXCallUpdate alloc] init];
-        callUpdate.hasVideo = hasVideo;
-        callUpdate.supportsGrouping = NO;
-        callUpdate.supportsUngrouping = NO;
-        callUpdate.supportsHolding = YES;
-        callUpdate.supportsDTMF = enableDTMF;
-        
-        [self.provider reportCallWithUUID:call.UUID updated:callUpdate];
     } else {
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"No call exists for you to connect"];
     }
@@ -408,6 +399,8 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     if (call) {
         CXSetMutedCallAction *muteAction = [[CXSetMutedCallAction alloc] initWithCallUUID:call.UUID muted:YES];
         CXTransaction *transaction = [[CXTransaction alloc] initWithAction:muteAction];
+        self.activeCalls[sessionId][@"pendingMuteActionUUID"] = muteAction.UUID;
+        self.activeCalls[sessionId][@"isMuted"] = @YES;
         [self logMessage:[NSString stringWithFormat:@"Programmatically Muting Call: %@", sessionId]];
         [self.callController requestTransaction:transaction completion:^(NSError * _Nullable error) {
             if (error == nil) {
@@ -433,6 +426,8 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     if (call) {
         CXSetMutedCallAction *unmuteAction = [[CXSetMutedCallAction alloc] initWithCallUUID:call.UUID muted:NO];
         CXTransaction *transaction = [[CXTransaction alloc] initWithAction:unmuteAction];
+        self.activeCalls[sessionId][@"pendingMuteActionUUID"] = unmuteAction.UUID;
+        self.activeCalls[sessionId][@"isMuted"] = @NO;
         [self logMessage:[NSString stringWithFormat:@"Programmatically Unmuting Call: %@", sessionId]];
         [self.callController requestTransaction:transaction completion:^(NSError * _Nullable error) {
             if (error == nil) {
@@ -864,6 +859,27 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         return;
     }
     [self logMessage:[NSString stringWithFormat:@"Callkit UI received %@ event, sessionId: %@", isMuted ? @"mute" : @"unmute", sessionId]];
+    NSUUID *expectedUUID = self.activeCalls[sessionId][@"pendingMuteActionUUID"];
+    if (expectedUUID != nil) {
+        // We submitted this transaction programmatically — only the action we created is valid.
+        if (![action.UUID isEqual:expectedUUID]) {
+            [self logMessage:@"performSetMutedCallAction: discarding unexpected programmatic action"];
+            [action fulfill];
+            return;
+        }
+        [self.activeCalls[sessionId] removeObjectForKey:@"pendingMuteActionUUID"];
+    } else {
+        // No pending UUID: could be a CallKit UI action or a spurious internal action.
+        // Discard if it doesn't change the current mute state.
+        NSNumber *currentMuted = self.activeCalls[sessionId][@"isMuted"];
+        if (currentMuted != nil && [currentMuted boolValue] == isMuted) {
+            [self logMessage:[NSString stringWithFormat:@"performSetMutedCallAction: discarding no-op action (already isMuted=%d)", isMuted]];
+            [action fulfill];
+            return;
+        }
+    }
+    // Sync our isMuted state to match what CallKit just told us.
+    self.activeCalls[sessionId][@"isMuted"] = @(isMuted);
 
     [action fulfill];
 

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -862,12 +862,13 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     NSUUID *expectedUUID = self.activeCalls[sessionId][@"pendingMuteActionUUID"];
     if (expectedUUID != nil) {
         // We submitted this transaction programmatically — only the action we created is valid.
+        // Always clear the pending UUID so future mute/unmute events are not blocked.
+        [self.activeCalls[sessionId] removeObjectForKey:@"pendingMuteActionUUID"];
         if (![action.UUID isEqual:expectedUUID]) {
             [self logMessage:@"performSetMutedCallAction: discarding unexpected programmatic action"];
             [action fulfill];
             return;
         }
-        [self.activeCalls[sessionId] removeObjectForKey:@"pendingMuteActionUUID"];
     } else {
         // No pending UUID: could be a CallKit UI action or a spurious internal action.
         // Discard if it doesn't change the current mute state.

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -126,13 +126,22 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 {
     @try {
         AVAudioSession *sessionInstance = [AVAudioSession sharedInstance];
-        [sessionInstance setCategory:AVAudioSessionCategoryPlayAndRecord
-                         withOptions:AVAudioSessionCategoryOptionMixWithOthers
-                                    | AVAudioSessionCategoryOptionAllowBluetooth
-                                    | AVAudioSessionCategoryOptionAllowAirPlay
-                                    | AVAudioSessionCategoryOptionAllowBluetoothA2DP
-                               error:nil];
-        [sessionInstance setMode:AVAudioSessionModeVoiceChat error:nil];
+        NSError *categoryError = nil;
+        BOOL categoryConfigured = [sessionInstance setCategory:AVAudioSessionCategoryPlayAndRecord
+                                                   withOptions:AVAudioSessionCategoryOptionMixWithOthers
+                                                              | AVAudioSessionCategoryOptionAllowBluetooth
+                                                              | AVAudioSessionCategoryOptionAllowAirPlay
+                                                              | AVAudioSessionCategoryOptionAllowBluetoothA2DP
+                                                         error:&categoryError];
+        if (!categoryConfigured) {
+            [self logMessage:[NSString stringWithFormat:@"Failed to set audio session category: %@", categoryError]];
+        }
+
+        NSError *modeError = nil;
+        BOOL modeConfigured = [sessionInstance setMode:AVAudioSessionModeVoiceChat error:&modeError];
+        if (!modeConfigured) {
+            [self logMessage:[NSString stringWithFormat:@"Failed to set audio session mode: %@", modeError]];
+        }
     }
     @catch (NSException *exception) {
         [self logMessage:@"Unknown error returned from setupAudioSession"];
@@ -399,11 +408,11 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     if (call) {
         CXSetMutedCallAction *muteAction = [[CXSetMutedCallAction alloc] initWithCallUUID:call.UUID muted:YES];
         CXTransaction *transaction = [[CXTransaction alloc] initWithAction:muteAction];
-        self.activeCalls[sessionId][@"pendingMuteActionUUID"] = muteAction.UUID;
-        self.activeCalls[sessionId][@"isMuted"] = @YES;
         [self logMessage:[NSString stringWithFormat:@"Programmatically Muting Call: %@", sessionId]];
         [self.callController requestTransaction:transaction completion:^(NSError * _Nullable error) {
             if (error == nil) {
+                self.activeCalls[sessionId][@"pendingMuteActionUUID"] = muteAction.UUID;
+                self.activeCalls[sessionId][@"isMuted"] = @YES;
                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Muted Successfully"];
             } else {
                 [self logMessage:@"Error occurred muting Call"];
@@ -426,11 +435,11 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     if (call) {
         CXSetMutedCallAction *unmuteAction = [[CXSetMutedCallAction alloc] initWithCallUUID:call.UUID muted:NO];
         CXTransaction *transaction = [[CXTransaction alloc] initWithAction:unmuteAction];
-        self.activeCalls[sessionId][@"pendingMuteActionUUID"] = unmuteAction.UUID;
-        self.activeCalls[sessionId][@"isMuted"] = @NO;
         [self logMessage:[NSString stringWithFormat:@"Programmatically Unmuting Call: %@", sessionId]];
         [self.callController requestTransaction:transaction completion:^(NSError * _Nullable error) {
             if (error == nil) {
+                self.activeCalls[sessionId][@"pendingMuteActionUUID"] = unmuteAction.UUID;
+                self.activeCalls[sessionId][@"isMuted"] = @NO;
                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Unmuted Successfully"];
             } else {
                 [self logMessage:@"Error occurred unmuting Call"];


### PR DESCRIPTION
Making the iOS callkit plugin more robust, by fixing some bugs and adding some bandaids.

List of changes from top to bottom:

1. Setup the CordovaCall audio session the same as iosrtc to prevent a category change when iosrtc also calls `setCategory` with a different set of modes/options.
2. Don't update the call config in `connectCall`, there is only 1-2 seconds between `sendCall` -> `connectCall` for outbound and `receiveCall` -> `connectCall` for inbound. We should have those values set before the call is started.
3. Add back filtering out mute/unmute, but only if they are out of sequence. IE you mute + unmute at the same time, unmute callback happens before mute callback. (temporary, can be removed once we make the entire sequence a promise)
  3a. Discard Callkit UI callback if it doesn't update the Callkit internal state

Bugs/Quirks:
- Mute state change during a category change causes Callkit to reset the internal state, IE when trying to unmute it'll emit a mute then unmute in quick succession to fix things. Normally this is fine but Conference Calls has a significant delay before sending to server and getting response before mute state actually changes, causing infinite loop.