### PR TITLE
have callkit control the audio session and audio output

### DIFF
--- a/src/ios/CordovaCall.h
+++ b/src/ios/CordovaCall.h
@@ -17,7 +17,6 @@
 @property (nonatomic, strong) CXCallController *callController;
 @property (nonatomic, strong) NSMutableDictionary<NSString *, NSMutableDictionary *> *activeCalls; // Stores each active call, mapped by call ID
 
-- (void)updateProviderConfig;
 - (void)setupAudioSession;
 
 - (void)setAppName:(CDVInvokedUrlCommand*)command;

--- a/src/ios/CordovaCall.h
+++ b/src/ios/CordovaCall.h
@@ -1,8 +1,12 @@
 #import <Cordova/CDV.h>
 #import <PushKit/PushKit.h>
 #import <CallKit/CallKit.h>
+#import <WebKit/WebKit.h>
 
-@interface CordovaCall : CDVPlugin <PKPushRegistryDelegate, CXProviderDelegate>
+@interface CordovaCall : CDVPlugin <PKPushRegistryDelegate, CXProviderDelegate, WKUIDelegate>
+
+// WKUIDelegate chain — holds the original UIDelegate so we can forward unhandled messages
+@property (nonatomic, weak) id<WKUIDelegate> originalUIDelegate;
 
 // PushKit
 @property (nonatomic, copy) NSString *VoIPPushCallbackId;

--- a/src/ios/CordovaCall.h
+++ b/src/ios/CordovaCall.h
@@ -17,6 +17,7 @@
 @property (nonatomic, strong) CXCallController *callController;
 @property (nonatomic, strong) NSMutableDictionary<NSString *, NSMutableDictionary *> *activeCalls; // Stores each active call, mapped by call ID
 
+- (void)updateProviderConfig;
 - (void)setupAudioSession;
 
 - (void)setAppName:(CDVInvokedUrlCommand*)command;

--- a/src/ios/CordovaCall.h
+++ b/src/ios/CordovaCall.h
@@ -1,6 +1,7 @@
 #import <Cordova/CDV.h>
 #import <PushKit/PushKit.h>
 #import <CallKit/CallKit.h>
+
 @interface CordovaCall : CDVPlugin <PKPushRegistryDelegate, CXProviderDelegate>
 
 // PushKit

--- a/src/ios/CordovaCall.h
+++ b/src/ios/CordovaCall.h
@@ -1,12 +1,7 @@
 #import <Cordova/CDV.h>
 #import <PushKit/PushKit.h>
 #import <CallKit/CallKit.h>
-#import <WebKit/WebKit.h>
-
-@interface CordovaCall : CDVPlugin <PKPushRegistryDelegate, CXProviderDelegate, WKUIDelegate>
-
-// WKUIDelegate chain — holds the original UIDelegate so we can forward unhandled messages
-@property (nonatomic, weak) id<WKUIDelegate> originalUIDelegate;
+@interface CordovaCall : CDVPlugin <PKPushRegistryDelegate, CXProviderDelegate>
 
 // PushKit
 @property (nonatomic, copy) NSString *VoIPPushCallbackId;

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -17,6 +17,7 @@ BOOL includeInRecents = NO;
 NSMutableDictionary<NSString*, NSMutableArray*> *callbackIds;
 NSDictionary* pendingCallFromRecents;
 BOOL monitorAudioRouteChange = NO;
+BOOL isSpeakerOn = NO;
 BOOL enableDTMF = YES;
 PKPushRegistry *_voipRegistry;
 
@@ -97,54 +98,30 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 }
 
 // CallKit - Interface
-- (void)updateProviderConfig
-{
-    CXProviderConfiguration *providerConfiguration;
-    providerConfiguration = [[CXProviderConfiguration alloc] initWithLocalizedName:appName];
-    providerConfiguration.maximumCallGroups = 2; // Max simultaneous active calls allowed
-    providerConfiguration.maximumCallsPerCallGroup = 5; // Max calls allowed to be handled at once as a group, including held calls
-    if(ringtone != nil) {
-        providerConfiguration.ringtoneSound = ringtone;
-    }
-    if(icon != nil) {
-        UIImage *iconImage = [UIImage imageNamed:icon];
-        NSData *iconData = UIImagePNGRepresentation(iconImage);
-        providerConfiguration.iconTemplateImageData = iconData;
-    }
-    NSMutableSet *handleTypes = [[NSMutableSet alloc] init];
-    [handleTypes addObject:@(CXHandleTypePhoneNumber)];
-    providerConfiguration.supportedHandleTypes = handleTypes;
-    providerConfiguration.supportsVideo = hasVideo;
-    if (@available(iOS 11.0, *)) {
-        providerConfiguration.includesCallsInRecents = includeInRecents;
-    }
-
-    self.provider.configuration = providerConfiguration;
-}
-
 - (void)setupAudioSession
 {
+    RTCAudioSession *rtcSession = [RTCAudioSession sharedInstance];
+    [rtcSession lockForConfiguration];
     @try {
-        AVAudioSession *sessionInstance = [AVAudioSession sharedInstance];
         NSError *categoryError = nil;
-        BOOL categoryConfigured = [sessionInstance setCategory:AVAudioSessionCategoryPlayAndRecord
-                                                   withOptions:AVAudioSessionCategoryOptionMixWithOthers
-                                                              | AVAudioSessionCategoryOptionAllowBluetooth
-                                                              | AVAudioSessionCategoryOptionAllowAirPlay
-                                                              | AVAudioSessionCategoryOptionAllowBluetoothA2DP
-                                                         error:&categoryError];
+        BOOL categoryConfigured = [rtcSession setCategory:AVAudioSessionCategoryPlayAndRecord
+                                              withOptions:AVAudioSessionCategoryOptionAllowBluetoothHFP
+                                                   error:&categoryError];
         if (!categoryConfigured) {
             [self logMessage:[NSString stringWithFormat:@"Failed to set audio session category: %@", categoryError]];
         }
 
         NSError *modeError = nil;
-        BOOL modeConfigured = [sessionInstance setMode:AVAudioSessionModeVoiceChat error:&modeError];
+        BOOL modeConfigured = [rtcSession setMode:hasVideo ? AVAudioSessionModeVideoChat : AVAudioSessionModeVoiceChat error:&modeError];
         if (!modeConfigured) {
             [self logMessage:[NSString stringWithFormat:@"Failed to set audio session mode: %@", modeError]];
         }
     }
     @catch (NSException *exception) {
         [self logMessage:@"Unknown error returned from setupAudioSession"];
+    }
+    @finally {
+        [rtcSession unlockForConfiguration];
     }
 }
 
@@ -155,7 +132,18 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 
     if (proposedAppName != nil && [proposedAppName length] > 0) {
         appName = proposedAppName;
-        [self updateProviderConfig];
+        CXProviderConfiguration *existing = self.provider.configuration;
+        CXProviderConfiguration *config = [[CXProviderConfiguration alloc] initWithLocalizedName:appName];
+        config.maximumCallGroups = existing.maximumCallGroups;
+        config.maximumCallsPerCallGroup = existing.maximumCallsPerCallGroup;
+        config.ringtoneSound = existing.ringtoneSound;
+        config.iconTemplateImageData = existing.iconTemplateImageData;
+        config.supportedHandleTypes = existing.supportedHandleTypes;
+        config.supportsVideo = existing.supportsVideo;
+        if (@available(iOS 11.0, *)) {
+            config.includesCallsInRecents = existing.includesCallsInRecents;
+        }
+        self.provider.configuration = config;
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"App Name Changed Successfully"];
     } else {
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"App Name Can't Be Empty"];
@@ -175,7 +163,9 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"This icon does not exist. Make sure to add it to your project the right way."];
     } else {
         icon = proposedIconName;
-        [self updateProviderConfig];
+        CXProviderConfiguration *config = self.provider.configuration;
+        config.iconTemplateImageData = UIImagePNGRepresentation([UIImage imageNamed:icon]);
+        self.provider.configuration = config;
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Icon Changed Successfully"];
     }
 
@@ -191,7 +181,9 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Ringtone Name Can't Be Empty"];
     } else {
         ringtone = [NSString stringWithFormat: @"%@.caf", proposedRingtoneName];
-        [self updateProviderConfig];
+        CXProviderConfiguration *config = self.provider.configuration;
+        config.ringtoneSound = ringtone;
+        self.provider.configuration = config;
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Ringtone Changed Successfully"];
     }
 
@@ -202,7 +194,11 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 {
     CDVPluginResult* pluginResult = nil;
     includeInRecents = [[command.arguments objectAtIndex:0] boolValue];
-    [self updateProviderConfig];
+    if (@available(iOS 11.0, *)) {
+        CXProviderConfiguration *config = self.provider.configuration;
+        config.includesCallsInRecents = includeInRecents;
+        self.provider.configuration = config;
+    }
     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"includeInRecents Changed Successfully"];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
@@ -219,7 +215,10 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 {
     CDVPluginResult* pluginResult = nil;
     hasVideo = [[command.arguments objectAtIndex:0] boolValue];
-    [self updateProviderConfig];
+    CXProviderConfiguration *config = self.provider.configuration;
+    config.supportsVideo = hasVideo;
+    self.provider.configuration = config;
+    [self setupAudioSession];
     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"hasVideo Changed Successfully"];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
@@ -456,12 +455,17 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 - (void)speakerOn:(CDVInvokedUrlCommand*)command
 {
     CDVPluginResult* pluginResult = nil;
-    AVAudioSession *sessionInstance = [AVAudioSession sharedInstance];
+    RTCAudioSession *rtcSession = [RTCAudioSession sharedInstance];
     [self logMessage:@"Programmatically turning speaker on"];
-    BOOL success = [sessionInstance overrideOutputAudioPort:AVAudioSessionPortOverrideSpeaker error:nil];
+    [rtcSession lockForConfiguration];
+    NSError *error = nil;
+    BOOL success = [rtcSession overrideOutputAudioPort:AVAudioSessionPortOverrideSpeaker error:&error];
+    [rtcSession unlockForConfiguration];
     if(success) {
+      isSpeakerOn = YES;
       pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Speakerphone is on"];
     } else {
+      [self logMessage:[NSString stringWithFormat:@"speakerOn failed: %@", error]];
       pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"An error occurred"];
     }
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
@@ -470,12 +474,17 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 - (void)speakerOff:(CDVInvokedUrlCommand*)command
 {
     CDVPluginResult* pluginResult = nil;
-    AVAudioSession *sessionInstance = [AVAudioSession sharedInstance];
+    RTCAudioSession *rtcSession = [RTCAudioSession sharedInstance];
     [self logMessage:@"Programmatically turning speaker off"];
-    BOOL success = [sessionInstance overrideOutputAudioPort:AVAudioSessionPortOverrideNone error:nil];
+    [rtcSession lockForConfiguration];
+    NSError *error = nil;
+    BOOL success = [rtcSession overrideOutputAudioPort:AVAudioSessionPortOverrideNone error:&error];
+    [rtcSession unlockForConfiguration];
     if(success) {
+      isSpeakerOn = NO;
       pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Speakerphone is off"];
     } else {
+      [self logMessage:[NSString stringWithFormat:@"speakerOff failed: %@", error]];
       pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"An error occurred"];
     }
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
@@ -485,8 +494,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 {
     CDVPluginResult* pluginResult = nil;
     @try {
-        AVAudioSession *sessionInstance = [AVAudioSession sharedInstance];
-        AVAudioSessionRouteDescription* currentRoute = [sessionInstance currentRoute];
+        AVAudioSessionRouteDescription* currentRoute = [[RTCAudioSession sharedInstance] currentRoute];
 
         NSString* currentOutputType = @"Unknown";
         if([currentRoute.outputs count] > 0) {
@@ -564,7 +572,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         }
 
         AVAudioSessionRouteDescription* previousRouteKey = notification.userInfo[AVAudioSessionRouteChangePreviousRouteKey];
-        AVAudioSessionRouteDescription* currentRoute = [[AVAudioSession sharedInstance] currentRoute];
+        AVAudioSessionRouteDescription* currentRoute = [[RTCAudioSession sharedInstance] currentRoute];
 
         // Get current output type
         NSString* currentOutputType = @"Unknown";
@@ -572,6 +580,15 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 
         if([currentRoute.outputs count] > 0) {
             currentOutputType = [currentRoute.outputs[0] portType];
+        }
+
+        // Re-apply speaker override if user had speaker active and a device was unplugged
+        if (reason == AVAudioSessionRouteChangeReasonOldDeviceUnavailable && isSpeakerOn &&
+            ![currentOutputType isEqual:AVAudioSessionPortBuiltInSpeaker]) {
+            RTCAudioSession *rtcSession = [RTCAudioSession sharedInstance];
+            [rtcSession lockForConfiguration];
+            [rtcSession overrideOutputAudioPort:AVAudioSessionPortOverrideSpeaker error:nil];
+            [rtcSession unlockForConfiguration];
         }
 
         NSArray* outputs = [previousRouteKey outputs];
@@ -768,6 +785,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     [RTCAudioSession sharedInstance].isAudioEnabled = NO;
     [[RTCAudioSession sharedInstance] audioSessionDidDeactivate:audioSession];
     monitorAudioRouteChange = NO;
+    isSpeakerOn = NO;
 
     // Emit hold callback deferred from performSetHeldCallAction
     for (NSString *sessionId in self.activeCalls) {

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -3,7 +3,6 @@
 #import <AVFoundation/AVFoundation.h>
 #import "WebSocketAdvanced.h"
 #import <SocketRocket/SocketRocket.h>
-#import <WebRTC/RTCAudioSession.h>
 
 @implementation CordovaCall
 
@@ -127,34 +126,26 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 
 - (void)setupAudioSession
 {
-    RTCAudioSession *rtcSession = [RTCAudioSession sharedInstance];
-    [rtcSession lockForConfiguration];
-    @try {
-        NSError *categoryError = nil;
-        BOOL categoryConfigured = [rtcSession setCategory:AVAudioSessionCategoryPlayAndRecord
-                                              withOptions:AVAudioSessionCategoryOptionAllowBluetoothHFP
-                                                   error:&categoryError];
-        if (!categoryConfigured) {
-            [self logMessage:[NSString stringWithFormat:@"Failed to set audio session category: %@", categoryError]];
-        }
-
-        NSError *modeError = nil;
-        BOOL modeConfigured = [rtcSession setMode:hasVideo ? AVAudioSessionModeVideoChat : AVAudioSessionModeVoiceChat error:&modeError];
-        if (!modeConfigured) {
-            [self logMessage:[NSString stringWithFormat:@"Failed to set audio session mode: %@", modeError]];
-        }
-
-        // Reflect the default routing: VideoChat routes to speaker, VoiceChat routes to earpiece.
-        // Only set the default if the user hasn't explicitly overridden it yet (i.e., session is not active).
-        if (!monitorAudioRouteChange) {
-            isSpeakerOn = hasVideo;
-        }
+    AVAudioSession *session = [AVAudioSession sharedInstance];
+    NSError *categoryError = nil;
+    BOOL categoryConfigured = [session setCategory:AVAudioSessionCategoryPlayAndRecord
+                                       withOptions:AVAudioSessionCategoryOptionAllowBluetoothHFP
+                                             error:&categoryError];
+    if (!categoryConfigured) {
+        [self logMessage:[NSString stringWithFormat:@"Failed to set audio session category: %@", categoryError]];
     }
-    @catch (NSException *exception) {
-        [self logMessage:@"Unknown error returned from setupAudioSession"];
+
+    NSError *modeError = nil;
+    BOOL modeConfigured = [session setMode:hasVideo ? AVAudioSessionModeVideoChat : AVAudioSessionModeVoiceChat
+                                     error:&modeError];
+    if (!modeConfigured) {
+        [self logMessage:[NSString stringWithFormat:@"Failed to set audio session mode: %@", modeError]];
     }
-    @finally {
-        [rtcSession unlockForConfiguration];
+
+    // Reflect the default routing: VideoChat routes to speaker, VoiceChat routes to earpiece.
+    // Only set the default if the user hasn't explicitly overridden it yet (i.e., session is not active).
+    if (!monitorAudioRouteChange) {
+        isSpeakerOn = hasVideo;
     }
 }
 
@@ -466,12 +457,9 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 - (void)speakerOn:(CDVInvokedUrlCommand*)command
 {
     CDVPluginResult* pluginResult = nil;
-    RTCAudioSession *rtcSession = [RTCAudioSession sharedInstance];
     [self logMessage:@"Programmatically turning speaker on"];
-    [rtcSession lockForConfiguration];
     NSError *error = nil;
-    BOOL success = [rtcSession overrideOutputAudioPort:AVAudioSessionPortOverrideSpeaker error:&error];
-    [rtcSession unlockForConfiguration];
+    BOOL success = [[AVAudioSession sharedInstance] overrideOutputAudioPort:AVAudioSessionPortOverrideSpeaker error:&error];
     if(success) {
       isSpeakerOn = YES;
       pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Speakerphone is on"];
@@ -485,12 +473,9 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 - (void)speakerOff:(CDVInvokedUrlCommand*)command
 {
     CDVPluginResult* pluginResult = nil;
-    RTCAudioSession *rtcSession = [RTCAudioSession sharedInstance];
     [self logMessage:@"Programmatically turning speaker off"];
-    [rtcSession lockForConfiguration];
     NSError *error = nil;
-    BOOL success = [rtcSession overrideOutputAudioPort:AVAudioSessionPortOverrideNone error:&error];
-    [rtcSession unlockForConfiguration];
+    BOOL success = [[AVAudioSession sharedInstance] overrideOutputAudioPort:AVAudioSessionPortOverrideNone error:&error];
     if(success) {
       isSpeakerOn = NO;
       pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Speakerphone is off"];
@@ -517,7 +502,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
             return;
         }
 
-        AVAudioSessionRouteDescription* currentRoute = [[RTCAudioSession sharedInstance] currentRoute];
+        AVAudioSessionRouteDescription* currentRoute = [AVAudioSession sharedInstance].currentRoute;
 
         NSString* currentOutputType = @"Unknown";
         if([currentRoute.outputs count] > 0) {
@@ -597,20 +582,17 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 
         if (reason == AVAudioSessionRouteChangeReasonRouteConfigurationChange) {
             if (isSpeakerOn) {
-                RTCAudioSession *rtcSession = [RTCAudioSession sharedInstance];
-                AVAudioSessionRouteDescription* currentRoute = [rtcSession currentRoute];
+                AVAudioSessionRouteDescription* currentRoute = [AVAudioSession sharedInstance].currentRoute;
                 NSString* currentOutputType = ([currentRoute.outputs count] > 0) ? [currentRoute.outputs[0] portType] : @"";
                 if (![currentOutputType isEqual:AVAudioSessionPortBuiltInSpeaker]) {
-                    [rtcSession lockForConfiguration];
-                    [rtcSession overrideOutputAudioPort:AVAudioSessionPortOverrideSpeaker error:nil];
-                    [rtcSession unlockForConfiguration];
+                    [[AVAudioSession sharedInstance] overrideOutputAudioPort:AVAudioSessionPortOverrideSpeaker error:nil];
                 }
             }
             return;
         }
 
         AVAudioSessionRouteDescription* previousRouteKey = notification.userInfo[AVAudioSessionRouteChangePreviousRouteKey];
-        AVAudioSessionRouteDescription* currentRoute = [[RTCAudioSession sharedInstance] currentRoute];
+        AVAudioSessionRouteDescription* currentRoute = [AVAudioSession sharedInstance].currentRoute;
 
         // Get current output type
         NSString* currentOutputType = @"Unknown";
@@ -623,10 +605,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         // Re-apply speaker override if user had speaker active and a device was unplugged
         if (reason == AVAudioSessionRouteChangeReasonOldDeviceUnavailable && isSpeakerOn &&
             ![currentOutputType isEqual:AVAudioSessionPortBuiltInSpeaker]) {
-            RTCAudioSession *rtcSession = [RTCAudioSession sharedInstance];
-            [rtcSession lockForConfiguration];
-            [rtcSession overrideOutputAudioPort:AVAudioSessionPortOverrideSpeaker error:nil];
-            [rtcSession unlockForConfiguration];
+            [[AVAudioSession sharedInstance] overrideOutputAudioPort:AVAudioSessionPortOverrideSpeaker error:nil];
         }
 
         NSArray* outputs = [previousRouteKey outputs];
@@ -798,17 +777,12 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 - (void)provider:(CXProvider *)provider didActivateAudioSession:(AVAudioSession *)audioSession
 {
     [self logMessage:@"activated audio"];
-    [[RTCAudioSession sharedInstance] audioSessionDidActivate:audioSession];
-    [RTCAudioSession sharedInstance].isAudioEnabled = YES;
     monitorAudioRouteChange = YES;
 
     // Apply speaker override for video calls (isSpeakerOn = YES set in setupAudioSession)
     // and for the edge case where speakerOn() was called before the session activated.
     if (isSpeakerOn) {
-        RTCAudioSession *rtcSession = [RTCAudioSession sharedInstance];
-        [rtcSession lockForConfiguration];
-        [rtcSession overrideOutputAudioPort:AVAudioSessionPortOverrideSpeaker error:nil];
-        [rtcSession unlockForConfiguration];
+        [audioSession overrideOutputAudioPort:AVAudioSessionPortOverrideSpeaker error:nil];
     }
 
     // Emit unhold callback deferred from performSetHeldCallAction
@@ -829,17 +803,13 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 - (void)provider:(CXProvider *)provider didDeactivateAudioSession:(AVAudioSession *)audioSession
 {
     [self logMessage:@"deactivated audio"];
-    [RTCAudioSession sharedInstance].isAudioEnabled = NO;
-    [[RTCAudioSession sharedInstance] audioSessionDidDeactivate:audioSession];
     monitorAudioRouteChange = NO;
 
     // Restore to a passive category on call end (not hold) so any post-call audio
     // (tones, notifications) plays through a deterministic route and doesn't double-play.
     if (self.activeCalls.count == 0) {
-        RTCAudioSession *rtcSession = [RTCAudioSession sharedInstance];
-        [rtcSession lockForConfiguration];
-        [rtcSession setCategory:AVAudioSessionCategoryPlayback withOptions:0 error:nil];
-        [rtcSession unlockForConfiguration];
+        [self logMessage:@"No active calls, resetting audio session to passive category"];
+        [audioSession setCategory:AVAudioSessionCategoryPlayback withOptions:0 error:nil];
     }
 
     // Emit hold callback deferred from performSetHeldCallAction

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -94,10 +94,6 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     webSockets = [[NSMutableDictionary alloc] init];
 
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleRemotePushNotification:) name:@"CallkitHandleRemotePushNotification" object:nil];
-
-    // Inject WKUIDelegate media-capture permission grant so getUserMedia in WKWebView
-    // does not prompt the user on every session (iOS 15+).
-    [self _injectMediaCapturePermissionDelegate];
 }
 
 // CallKit - Interface
@@ -142,8 +138,6 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         [self logMessage:[NSString stringWithFormat:@"Failed to set audio session mode: %@", modeError]];
     }
 
-    // Reflect the default routing: VideoChat routes to speaker, VoiceChat routes to earpiece.
-    // Only set the default if the user hasn't explicitly overridden it yet (i.e., session is not active).
     if (!monitorAudioRouteChange) {
         isSpeakerOn = hasVideo;
     }
@@ -777,6 +771,10 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 - (void)provider:(CXProvider *)provider didActivateAudioSession:(AVAudioSession *)audioSession
 {
     [self logMessage:@"activated audio"];
+    // Re-apply category and mode now that CallKit owns the session.
+    // WKWebView's WebRTC audio unit reads session config at activation time,
+    // so settings applied earlier in performAnswerCallAction may have been reset.
+    [self setupAudioSession];
     monitorAudioRouteChange = YES;
 
     // Apply speaker override for video calls (isSpeakerOn = YES set in setupAudioSession)
@@ -785,10 +783,29 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         [audioSession overrideOutputAudioPort:AVAudioSessionPortOverrideSpeaker error:nil];
     }
 
+    // Emit answer callback deferred from performAnswerCallAction
+    for (NSString *sessionId in self.activeCalls) {
+        NSNumber *pendingAnswer = self.activeCalls[sessionId][@"pendingAnswerEmit"];
+        if (pendingAnswer != nil && [pendingAnswer boolValue] == YES) {
+            [self logMessage:[NSString stringWithFormat:@"didActivateAudioSession: emitting deferred answer for sessionId=%@", sessionId]];
+            [self.activeCalls[sessionId] removeObjectForKey:@"pendingAnswerEmit"];
+            if ([callbackIds[@"answer"] count] == 0) {
+                NSDictionary *pendingResponse = @{
+                    @"type": PENDING_RESPONSE_ANSWER,
+                    @"sessionId": sessionId
+                };
+                [pendingCallResponses addObject:pendingResponse];
+            } else {
+                [self triggerCordovaEventForCallResponse:@"answer" sessionId:sessionId];
+            }
+        }
+    }
+
     // Emit unhold callback deferred from performSetHeldCallAction
     for (NSString *sessionId in self.activeCalls) {
         NSNumber *pendingHold = self.activeCalls[sessionId][@"pendingHoldEmit"];
         if (pendingHold != nil && [pendingHold boolValue] == NO) {
+            [self logMessage:[NSString stringWithFormat:@"didActivateAudioSession: emitting deferred unhold for sessionId=%@", sessionId]];
             [self.activeCalls[sessionId] removeObjectForKey:@"pendingHoldEmit"];
             for (id callbackId in callbackIds[@"unhold"]) {
                 NSDictionary *resultDict = @{ @"message": @"unhold event called successfully", @"sessionId": sessionId };
@@ -805,17 +822,11 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     [self logMessage:@"deactivated audio"];
     monitorAudioRouteChange = NO;
 
-    // Restore to a passive category on call end (not hold) so any post-call audio
-    // (tones, notifications) plays through a deterministic route and doesn't double-play.
-    if (self.activeCalls.count == 0) {
-        [self logMessage:@"No active calls, resetting audio session to passive category"];
-        [audioSession setCategory:AVAudioSessionCategoryPlayback withOptions:0 error:nil];
-    }
-
     // Emit hold callback deferred from performSetHeldCallAction
     for (NSString *sessionId in self.activeCalls) {
         NSNumber *pendingHold = self.activeCalls[sessionId][@"pendingHoldEmit"];
         if (pendingHold != nil && [pendingHold boolValue] == YES) {
+            [self logMessage:[NSString stringWithFormat:@"didDeactivateAudioSession: emitting deferred hold for sessionId=%@", sessionId]];
             [self.activeCalls[sessionId] removeObjectForKey:@"pendingHoldEmit"];
             for (id callbackId in callbackIds[@"hold"]) {
                 NSDictionary *resultDict = @{ @"message": @"hold event called successfully", @"sessionId": sessionId };
@@ -834,16 +845,9 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     [action fulfill];
 
     NSString *sessionId = [self sessionIdForUUID:action.callUUID];
-    if ([callbackIds[@"answer"] count] == 0) {
-        // callbackId for event not registered, add to pending to trigger on registration
-        NSDictionary *pendingResponse = @{
-            @"type": PENDING_RESPONSE_ANSWER,
-            @"sessionId": sessionId
-        };
-        [pendingCallResponses addObject:pendingResponse];
-    } else {
-        [self triggerCordovaEventForCallResponse:@"answer" sessionId:sessionId];
-    }
+    // Defer the answer callback until didActivateAudioSession so that JsSIP's gUM
+    // runs only after the audio session is fully active and owned by CallKit.
+    self.activeCalls[sessionId][@"pendingAnswerEmit"] = @YES;
 
     UIApplication *app = [UIApplication sharedApplication];
     bgTask = [app beginBackgroundTaskWithExpirationHandler:^{
@@ -1400,52 +1404,5 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 - (void)logMessage:(NSString *)message
 {
     NSLog(@"[CordovaCall]: %@", message);
-}
-
-// Takes over as WKWebView UIDelegate and chains the original delegate so Cordova's
-// own UIDelegate methods (alert, confirm, etc.) are not lost.
-- (void)_injectMediaCapturePermissionDelegate {
-    if (@available(iOS 15.0, *)) {
-        if ([self.webView isKindOfClass:[WKWebView class]]) {
-            WKWebView *wkWebView = (WKWebView *)self.webView;
-            self.originalUIDelegate = wkWebView.UIDelegate;
-            wkWebView.UIDelegate = self;
-        }
-    }
-}
-
-// Grants WKWebView-level microphone access based on the OS-level AVCaptureDevice
-// authorization status, so JsSIP's getUserMedia does not show a per-session prompt.
-// - Already authorized at OS level → grant immediately.
-// - Not yet determined → trigger the OS prompt, then reflect the user's choice.
-// - Denied/restricted → deny so WebRTC fails gracefully.
-- (void)webView:(WKWebView *)wkWebView
-    requestMediaCapturePermissionForOrigin:(WKSecurityOrigin *)origin
-    initiatedByFrame:(WKFrameInfo *)frame
-    type:(WKMediaCaptureType)type
-    decisionHandler:(void (^)(WKPermissionDecision))decisionHandler
-    API_AVAILABLE(ios(15.0))
-{
-    AVAuthorizationStatus status = [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeAudio];
-    if (status == AVAuthorizationStatusAuthorized) {
-        decisionHandler(WKPermissionDecisionGrant);
-    } else if (status == AVAuthorizationStatusNotDetermined) {
-        [AVCaptureDevice requestAccessForMediaType:AVMediaTypeAudio completionHandler:^(BOOL granted) {
-            dispatch_async(dispatch_get_main_queue(), ^{
-                decisionHandler(granted ? WKPermissionDecisionGrant : WKPermissionDecisionDeny);
-            });
-        }];
-    } else {
-        decisionHandler(WKPermissionDecisionDeny);
-    }
-}
-
-// Forward all other WKUIDelegate messages (e.g. JS alert/confirm/prompt panels)
-// to Cordova's original UIDelegate so nothing is lost.
-- (id)forwardingTargetForSelector:(SEL)aSelector {
-    if ([self.originalUIDelegate respondsToSelector:aSelector]) {
-        return self.originalUIDelegate;
-    }
-    return [super forwardingTargetForSelector:aSelector];
 }
 @end

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -95,6 +95,10 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     webSockets = [[NSMutableDictionary alloc] init];
 
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleRemotePushNotification:) name:@"CallkitHandleRemotePushNotification" object:nil];
+
+    // Inject WKUIDelegate media-capture permission grant so getUserMedia in WKWebView
+    // does not prompt the user on every session (iOS 15+).
+    [self _injectMediaCapturePermissionDelegate];
 }
 
 // CallKit - Interface
@@ -1276,7 +1280,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     [self.commandDelegate sendPluginResult:pluginResult callbackId:self.VoIPPushCallbackId];
 }
 
-#define PushKit Delegate Methods
+#pragma mark - PushKit Delegate Methods
 - (void)pushRegistry:(PKPushRegistry *)registry didUpdatePushCredentials:(PKPushCredentials *)credentials forType:(PKPushType)type{
     if([credentials.token length] == 0) {
         [self logMessage:@"No device token!"];
@@ -1426,5 +1430,52 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 - (void)logMessage:(NSString *)message
 {
     NSLog(@"[CordovaCall]: %@", message);
+}
+
+// Takes over as WKWebView UIDelegate and chains the original delegate so Cordova's
+// own UIDelegate methods (alert, confirm, etc.) are not lost.
+- (void)_injectMediaCapturePermissionDelegate {
+    if (@available(iOS 15.0, *)) {
+        if ([self.webView isKindOfClass:[WKWebView class]]) {
+            WKWebView *wkWebView = (WKWebView *)self.webView;
+            self.originalUIDelegate = wkWebView.UIDelegate;
+            wkWebView.UIDelegate = self;
+        }
+    }
+}
+
+// Grants WKWebView-level microphone access based on the OS-level AVCaptureDevice
+// authorization status, so JsSIP's getUserMedia does not show a per-session prompt.
+// - Already authorized at OS level → grant immediately.
+// - Not yet determined → trigger the OS prompt, then reflect the user's choice.
+// - Denied/restricted → deny so WebRTC fails gracefully.
+- (void)webView:(WKWebView *)wkWebView
+    requestMediaCapturePermissionForOrigin:(WKSecurityOrigin *)origin
+    initiatedByFrame:(WKFrameInfo *)frame
+    type:(WKMediaCaptureType)type
+    decisionHandler:(void (^)(WKPermissionDecision))decisionHandler
+    API_AVAILABLE(ios(15.0))
+{
+    AVAuthorizationStatus status = [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeAudio];
+    if (status == AVAuthorizationStatusAuthorized) {
+        decisionHandler(WKPermissionDecisionGrant);
+    } else if (status == AVAuthorizationStatusNotDetermined) {
+        [AVCaptureDevice requestAccessForMediaType:AVMediaTypeAudio completionHandler:^(BOOL granted) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                decisionHandler(granted ? WKPermissionDecisionGrant : WKPermissionDecisionDeny);
+            });
+        }];
+    } else {
+        decisionHandler(WKPermissionDecisionDeny);
+    }
+}
+
+// Forward all other WKUIDelegate messages (e.g. JS alert/confirm/prompt panels)
+// to Cordova's original UIDelegate so nothing is lost.
+- (id)forwardingTargetForSelector:(SEL)aSelector {
+    if ([self.originalUIDelegate respondsToSelector:aSelector]) {
+        return self.originalUIDelegate;
+    }
+    return [super forwardingTargetForSelector:aSelector];
 }
 @end

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -782,8 +782,8 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 - (void)provider:(CXProvider *)provider didActivateAudioSession:(AVAudioSession *)audioSession
 {
     [self logMessage:@"activated audio"];
-    [RTCAudioSession sharedInstance].isAudioEnabled = YES;
     [[RTCAudioSession sharedInstance] audioSessionDidActivate:audioSession];
+    [RTCAudioSession sharedInstance].isAudioEnabled = YES;
     monitorAudioRouteChange = YES;
 
     // Apply speaker override for video calls (isSpeakerOn = YES set in setupAudioSession)

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -98,6 +98,29 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 }
 
 // CallKit - Interface
+- (void)updateProviderConfig
+{
+    CXProviderConfiguration *providerConfiguration;
+    providerConfiguration = [[CXProviderConfiguration alloc] initWithLocalizedName:appName];
+    providerConfiguration.maximumCallGroups = 2; // Max simultaneous active calls allowed
+    providerConfiguration.maximumCallsPerCallGroup = 5; // Max calls allowed to be handled at once as a group, including held calls
+    if(ringtone != nil) {
+        providerConfiguration.ringtoneSound = ringtone;
+    }
+    if(icon != nil) {
+        UIImage *iconImage = [UIImage imageNamed:icon];
+        NSData *iconData = UIImagePNGRepresentation(iconImage);
+        providerConfiguration.iconTemplateImageData = iconData;
+    }
+    NSMutableSet *handleTypes = [[NSMutableSet alloc] init];
+    [handleTypes addObject:@(CXHandleTypePhoneNumber)];
+    providerConfiguration.supportedHandleTypes = handleTypes;
+    providerConfiguration.supportsVideo = hasVideo;
+    providerConfiguration.includesCallsInRecents = includeInRecents;
+
+    self.provider.configuration = providerConfiguration;
+}
+
 - (void)setupAudioSession
 {
     RTCAudioSession *rtcSession = [RTCAudioSession sharedInstance];
@@ -116,6 +139,12 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         if (!modeConfigured) {
             [self logMessage:[NSString stringWithFormat:@"Failed to set audio session mode: %@", modeError]];
         }
+
+        // Reflect the default routing: VideoChat routes to speaker, VoiceChat routes to earpiece.
+        // Only set the default if the user hasn't explicitly overridden it yet (i.e., session is not active).
+        if (!monitorAudioRouteChange) {
+            isSpeakerOn = hasVideo;
+        }
     }
     @catch (NSException *exception) {
         [self logMessage:@"Unknown error returned from setupAudioSession"];
@@ -132,18 +161,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 
     if (proposedAppName != nil && [proposedAppName length] > 0) {
         appName = proposedAppName;
-        CXProviderConfiguration *existing = self.provider.configuration;
-        CXProviderConfiguration *config = [[CXProviderConfiguration alloc] initWithLocalizedName:appName];
-        config.maximumCallGroups = existing.maximumCallGroups;
-        config.maximumCallsPerCallGroup = existing.maximumCallsPerCallGroup;
-        config.ringtoneSound = existing.ringtoneSound;
-        config.iconTemplateImageData = existing.iconTemplateImageData;
-        config.supportedHandleTypes = existing.supportedHandleTypes;
-        config.supportsVideo = existing.supportsVideo;
-        if (@available(iOS 11.0, *)) {
-            config.includesCallsInRecents = existing.includesCallsInRecents;
-        }
-        self.provider.configuration = config;
+        [self updateProviderConfig];
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"App Name Changed Successfully"];
     } else {
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"App Name Can't Be Empty"];
@@ -163,9 +181,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"This icon does not exist. Make sure to add it to your project the right way."];
     } else {
         icon = proposedIconName;
-        CXProviderConfiguration *config = self.provider.configuration;
-        config.iconTemplateImageData = UIImagePNGRepresentation([UIImage imageNamed:icon]);
-        self.provider.configuration = config;
+        [self updateProviderConfig];
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Icon Changed Successfully"];
     }
 
@@ -181,9 +197,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Ringtone Name Can't Be Empty"];
     } else {
         ringtone = [NSString stringWithFormat: @"%@.caf", proposedRingtoneName];
-        CXProviderConfiguration *config = self.provider.configuration;
-        config.ringtoneSound = ringtone;
-        self.provider.configuration = config;
+        [self updateProviderConfig];
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Ringtone Changed Successfully"];
     }
 
@@ -194,11 +208,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 {
     CDVPluginResult* pluginResult = nil;
     includeInRecents = [[command.arguments objectAtIndex:0] boolValue];
-    if (@available(iOS 11.0, *)) {
-        CXProviderConfiguration *config = self.provider.configuration;
-        config.includesCallsInRecents = includeInRecents;
-        self.provider.configuration = config;
-    }
+    [self updateProviderConfig];
     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"includeInRecents Changed Successfully"];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
@@ -215,9 +225,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 {
     CDVPluginResult* pluginResult = nil;
     hasVideo = [[command.arguments objectAtIndex:0] boolValue];
-    CXProviderConfiguration *config = self.provider.configuration;
-    config.supportsVideo = hasVideo;
-    self.provider.configuration = config;
+    [self updateProviderConfig];
     [self setupAudioSession];
     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"hasVideo Changed Successfully"];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
@@ -566,8 +574,23 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         NSNumber* reasonValue = notification.userInfo[AVAudioSessionRouteChangeReasonKey];
         int reason = [reasonValue intValue];
 
-        // Filter out unimportant route changes
-        if (reason == AVAudioSessionRouteChangeReasonUnknown || reason == AVAudioSessionRouteChangeReasonWakeFromSleep || reason == AVAudioSessionRouteChangeReasonRouteConfigurationChange) {
+        // Filter out unimportant route changes, but handle RouteConfigurationChange
+        // separately so we can re-apply the speaker override if WebRTC reconfigures the session
+        if (reason == AVAudioSessionRouteChangeReasonUnknown || reason == AVAudioSessionRouteChangeReasonWakeFromSleep) {
+            return;
+        }
+
+        if (reason == AVAudioSessionRouteChangeReasonRouteConfigurationChange) {
+            if (isSpeakerOn) {
+                RTCAudioSession *rtcSession = [RTCAudioSession sharedInstance];
+                AVAudioSessionRouteDescription* currentRoute = [rtcSession currentRoute];
+                NSString* currentOutputType = ([currentRoute.outputs count] > 0) ? [currentRoute.outputs[0] portType] : @"";
+                if (![currentOutputType isEqual:AVAudioSessionPortBuiltInSpeaker]) {
+                    [rtcSession lockForConfiguration];
+                    [rtcSession overrideOutputAudioPort:AVAudioSessionPortOverrideSpeaker error:nil];
+                    [rtcSession unlockForConfiguration];
+                }
+            }
             return;
         }
 
@@ -764,6 +787,15 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     [[RTCAudioSession sharedInstance] audioSessionDidActivate:audioSession];
     monitorAudioRouteChange = YES;
 
+    // Apply speaker override for video calls (isSpeakerOn = YES set in setupAudioSession)
+    // and for the edge case where speakerOn() was called before the session activated.
+    if (isSpeakerOn) {
+        RTCAudioSession *rtcSession = [RTCAudioSession sharedInstance];
+        [rtcSession lockForConfiguration];
+        [rtcSession overrideOutputAudioPort:AVAudioSessionPortOverrideSpeaker error:nil];
+        [rtcSession unlockForConfiguration];
+    }
+
     // Emit unhold callback deferred from performSetHeldCallAction
     for (NSString *sessionId in self.activeCalls) {
         NSNumber *pendingHold = self.activeCalls[sessionId][@"pendingHoldEmit"];
@@ -786,6 +818,13 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     [[RTCAudioSession sharedInstance] audioSessionDidDeactivate:audioSession];
     monitorAudioRouteChange = NO;
     isSpeakerOn = NO;
+
+    // Restore to a passive category so any post-call audio (tones, notifications) plays
+    // through a deterministic route and doesn't double-play across session transitions.
+    RTCAudioSession *rtcSession = [RTCAudioSession sharedInstance];
+    [rtcSession lockForConfiguration];
+    [rtcSession setCategory:AVAudioSessionCategoryPlayback withOptions:0 error:nil];
+    [rtcSession unlockForConfiguration];
 
     // Emit hold callback deferred from performSetHeldCallAction
     for (NSString *sessionId in self.activeCalls) {

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -226,7 +226,6 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     CDVPluginResult* pluginResult = nil;
     hasVideo = [[command.arguments objectAtIndex:0] boolValue];
     [self updateProviderConfig];
-    [self setupAudioSession];
     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"hasVideo Changed Successfully"];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
@@ -817,7 +816,6 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     [RTCAudioSession sharedInstance].isAudioEnabled = NO;
     [[RTCAudioSession sharedInstance] audioSessionDidDeactivate:audioSession];
     monitorAudioRouteChange = NO;
-    isSpeakerOn = NO;
 
     // Restore to a passive category so any post-call audio (tones, notifications) plays
     // through a deterministic route and doesn't double-play across session transitions.

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -501,6 +501,18 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 {
     CDVPluginResult* pluginResult = nil;
     @try {
+        // If a call exists but the audio session hasn't been activated yet (window between
+        // performAnswerCallAction and didActivateAudioSession), the hardware route still reflects
+        // the pre-call state (e.g. .playback → speaker) and is unreliable.
+        // Fall back to isSpeakerOn which was correctly set in setupAudioSession.
+        if (self.activeCalls.count > 0 && !monitorAudioRouteChange) {
+            NSString* inferredRoute = isSpeakerOn ? @"speaker" : @"earpiece";
+            [self logMessage:[NSString stringWithFormat:@"getAudioRoute: session not yet active, inferring from isSpeakerOn=%d -> %@", isSpeakerOn, inferredRoute]];
+            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:inferredRoute];
+            [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+            return;
+        }
+
         AVAudioSessionRouteDescription* currentRoute = [[RTCAudioSession sharedInstance] currentRoute];
 
         NSString* currentOutputType = @"Unknown";

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -3,6 +3,7 @@
 #import <AVFoundation/AVFoundation.h>
 #import "WebSocketAdvanced.h"
 #import <SocketRocket/SocketRocket.h>
+#import <WebRTC/RTCAudioSession.h>
 
 @implementation CordovaCall
 
@@ -742,7 +743,9 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 - (void)provider:(CXProvider *)provider didActivateAudioSession:(AVAudioSession *)audioSession
 {
     [self logMessage:@"activated audio"];
-
+    [[RTCAudioSession sharedInstance] audioSessionDidActivate:audioSession];
+    [RTCAudioSession sharedInstance].isAudioEnabled = YES;
+    monitorAudioRouteChange = YES;
 
     // Emit answer callback deferred from performAnswerCallAction
     for (NSString *sessionId in self.activeCalls) {
@@ -780,7 +783,9 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 - (void)provider:(CXProvider *)provider didDeactivateAudioSession:(AVAudioSession *)audioSession
 {
     [self logMessage:@"deactivated audio"];
-
+    [RTCAudioSession sharedInstance].isAudioEnabled = NO;
+    [[RTCAudioSession sharedInstance] audioSessionDidDeactivate:audioSession];
+    monitorAudioRouteChange = NO;
 
     // Emit hold callback deferred from performSetHeldCallAction
     for (NSString *sessionId in self.activeCalls) {

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -16,7 +16,6 @@ BOOL includeInRecents = NO;
 NSMutableDictionary<NSString*, NSMutableArray*> *callbackIds;
 NSDictionary* pendingCallFromRecents;
 BOOL monitorAudioRouteChange = NO;
-BOOL isSpeakerOn = NO;
 BOOL enableDTMF = YES;
 PKPushRegistry *_voipRegistry;
 
@@ -115,31 +114,36 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     [handleTypes addObject:@(CXHandleTypePhoneNumber)];
     providerConfiguration.supportedHandleTypes = handleTypes;
     providerConfiguration.supportsVideo = hasVideo;
-    providerConfiguration.includesCallsInRecents = includeInRecents;
+    if (@available(iOS 11.0, *)) {
+        providerConfiguration.includesCallsInRecents = includeInRecents;
+    }
 
     self.provider.configuration = providerConfiguration;
 }
 
 - (void)setupAudioSession
 {
-    AVAudioSession *session = [AVAudioSession sharedInstance];
-    NSError *categoryError = nil;
-    BOOL categoryConfigured = [session setCategory:AVAudioSessionCategoryPlayAndRecord
-                                       withOptions:AVAudioSessionCategoryOptionAllowBluetoothHFP
-                                             error:&categoryError];
-    if (!categoryConfigured) {
-        [self logMessage:[NSString stringWithFormat:@"Failed to set audio session category: %@", categoryError]];
-    }
+    @try {
+        AVAudioSession *sessionInstance = [AVAudioSession sharedInstance];
+        NSError *categoryError = nil;
+        BOOL categoryConfigured = [sessionInstance setCategory:AVAudioSessionCategoryPlayAndRecord
+                                                   withOptions:AVAudioSessionCategoryOptionMixWithOthers
+                                                              | AVAudioSessionCategoryOptionAllowBluetooth
+                                                              | AVAudioSessionCategoryOptionAllowAirPlay
+                                                              | AVAudioSessionCategoryOptionAllowBluetoothA2DP
+                                                         error:&categoryError];
+        if (!categoryConfigured) {
+            [self logMessage:[NSString stringWithFormat:@"Failed to set audio session category: %@", categoryError]];
+        }
 
-    NSError *modeError = nil;
-    BOOL modeConfigured = [session setMode:hasVideo ? AVAudioSessionModeVideoChat : AVAudioSessionModeVoiceChat
-                                     error:&modeError];
-    if (!modeConfigured) {
-        [self logMessage:[NSString stringWithFormat:@"Failed to set audio session mode: %@", modeError]];
+        NSError *modeError = nil;
+        BOOL modeConfigured = [sessionInstance setMode:AVAudioSessionModeVoiceChat error:&modeError];
+        if (!modeConfigured) {
+            [self logMessage:[NSString stringWithFormat:@"Failed to set audio session mode: %@", modeError]];
+        }
     }
-
-    if (!monitorAudioRouteChange) {
-        isSpeakerOn = hasVideo;
+    @catch (NSException *exception) {
+        [self logMessage:@"Unknown error returned from setupAudioSession"];
     }
 }
 
@@ -451,14 +455,12 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 - (void)speakerOn:(CDVInvokedUrlCommand*)command
 {
     CDVPluginResult* pluginResult = nil;
+    AVAudioSession *sessionInstance = [AVAudioSession sharedInstance];
     [self logMessage:@"Programmatically turning speaker on"];
-    NSError *error = nil;
-    BOOL success = [[AVAudioSession sharedInstance] overrideOutputAudioPort:AVAudioSessionPortOverrideSpeaker error:&error];
+    BOOL success = [sessionInstance overrideOutputAudioPort:AVAudioSessionPortOverrideSpeaker error:nil];
     if(success) {
-      isSpeakerOn = YES;
       pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Speakerphone is on"];
     } else {
-      [self logMessage:[NSString stringWithFormat:@"speakerOn failed: %@", error]];
       pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"An error occurred"];
     }
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
@@ -467,14 +469,12 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 - (void)speakerOff:(CDVInvokedUrlCommand*)command
 {
     CDVPluginResult* pluginResult = nil;
+    AVAudioSession *sessionInstance = [AVAudioSession sharedInstance];
     [self logMessage:@"Programmatically turning speaker off"];
-    NSError *error = nil;
-    BOOL success = [[AVAudioSession sharedInstance] overrideOutputAudioPort:AVAudioSessionPortOverrideNone error:&error];
+    BOOL success = [sessionInstance overrideOutputAudioPort:AVAudioSessionPortOverrideNone error:nil];
     if(success) {
-      isSpeakerOn = NO;
       pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Speakerphone is off"];
     } else {
-      [self logMessage:[NSString stringWithFormat:@"speakerOff failed: %@", error]];
       pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"An error occurred"];
     }
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
@@ -484,19 +484,8 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 {
     CDVPluginResult* pluginResult = nil;
     @try {
-        // If a call exists but the audio session hasn't been activated yet (window between
-        // performAnswerCallAction and didActivateAudioSession), the hardware route still reflects
-        // the pre-call state (e.g. .playback → speaker) and is unreliable.
-        // Fall back to isSpeakerOn which was correctly set in setupAudioSession.
-        if (self.activeCalls.count > 0 && !monitorAudioRouteChange) {
-            NSString* inferredRoute = isSpeakerOn ? @"speaker" : @"earpiece";
-            [self logMessage:[NSString stringWithFormat:@"getAudioRoute: session not yet active, inferring from isSpeakerOn=%d -> %@", isSpeakerOn, inferredRoute]];
-            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:inferredRoute];
-            [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
-            return;
-        }
-
-        AVAudioSessionRouteDescription* currentRoute = [AVAudioSession sharedInstance].currentRoute;
+        AVAudioSession *sessionInstance = [AVAudioSession sharedInstance];
+        AVAudioSessionRouteDescription* currentRoute = [sessionInstance currentRoute];
 
         NSString* currentOutputType = @"Unknown";
         if([currentRoute.outputs count] > 0) {
@@ -568,25 +557,13 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         NSNumber* reasonValue = notification.userInfo[AVAudioSessionRouteChangeReasonKey];
         int reason = [reasonValue intValue];
 
-        // Filter out unimportant route changes, but handle RouteConfigurationChange
-        // separately so we can re-apply the speaker override if WebRTC reconfigures the session
-        if (reason == AVAudioSessionRouteChangeReasonUnknown || reason == AVAudioSessionRouteChangeReasonWakeFromSleep) {
-            return;
-        }
-
-        if (reason == AVAudioSessionRouteChangeReasonRouteConfigurationChange) {
-            if (isSpeakerOn) {
-                AVAudioSessionRouteDescription* currentRoute = [AVAudioSession sharedInstance].currentRoute;
-                NSString* currentOutputType = ([currentRoute.outputs count] > 0) ? [currentRoute.outputs[0] portType] : @"";
-                if (![currentOutputType isEqual:AVAudioSessionPortBuiltInSpeaker]) {
-                    [[AVAudioSession sharedInstance] overrideOutputAudioPort:AVAudioSessionPortOverrideSpeaker error:nil];
-                }
-            }
+        // Filter out unimportant route changes
+        if (reason == AVAudioSessionRouteChangeReasonUnknown || reason == AVAudioSessionRouteChangeReasonWakeFromSleep || reason == AVAudioSessionRouteChangeReasonRouteConfigurationChange) {
             return;
         }
 
         AVAudioSessionRouteDescription* previousRouteKey = notification.userInfo[AVAudioSessionRouteChangePreviousRouteKey];
-        AVAudioSessionRouteDescription* currentRoute = [AVAudioSession sharedInstance].currentRoute;
+        AVAudioSessionRouteDescription* currentRoute = [[AVAudioSession sharedInstance] currentRoute];
 
         // Get current output type
         NSString* currentOutputType = @"Unknown";
@@ -594,12 +571,6 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 
         if([currentRoute.outputs count] > 0) {
             currentOutputType = [currentRoute.outputs[0] portType];
-        }
-
-        // Re-apply speaker override if user had speaker active and a device was unplugged
-        if (reason == AVAudioSessionRouteChangeReasonOldDeviceUnavailable && isSpeakerOn &&
-            ![currentOutputType isEqual:AVAudioSessionPortBuiltInSpeaker]) {
-            [[AVAudioSession sharedInstance] overrideOutputAudioPort:AVAudioSessionPortOverrideSpeaker error:nil];
         }
 
         NSArray* outputs = [previousRouteKey outputs];
@@ -771,17 +742,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 - (void)provider:(CXProvider *)provider didActivateAudioSession:(AVAudioSession *)audioSession
 {
     [self logMessage:@"activated audio"];
-    // Re-apply category and mode now that CallKit owns the session.
-    // WKWebView's WebRTC audio unit reads session config at activation time,
-    // so settings applied earlier in performAnswerCallAction may have been reset.
-    [self setupAudioSession];
-    monitorAudioRouteChange = YES;
 
-    // Apply speaker override for video calls (isSpeakerOn = YES set in setupAudioSession)
-    // and for the edge case where speakerOn() was called before the session activated.
-    if (isSpeakerOn) {
-        [audioSession overrideOutputAudioPort:AVAudioSessionPortOverrideSpeaker error:nil];
-    }
 
     // Emit answer callback deferred from performAnswerCallAction
     for (NSString *sessionId in self.activeCalls) {
@@ -805,7 +766,6 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     for (NSString *sessionId in self.activeCalls) {
         NSNumber *pendingHold = self.activeCalls[sessionId][@"pendingHoldEmit"];
         if (pendingHold != nil && [pendingHold boolValue] == NO) {
-            [self logMessage:[NSString stringWithFormat:@"didActivateAudioSession: emitting deferred unhold for sessionId=%@", sessionId]];
             [self.activeCalls[sessionId] removeObjectForKey:@"pendingHoldEmit"];
             for (id callbackId in callbackIds[@"unhold"]) {
                 NSDictionary *resultDict = @{ @"message": @"unhold event called successfully", @"sessionId": sessionId };
@@ -820,13 +780,12 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 - (void)provider:(CXProvider *)provider didDeactivateAudioSession:(AVAudioSession *)audioSession
 {
     [self logMessage:@"deactivated audio"];
-    monitorAudioRouteChange = NO;
+
 
     // Emit hold callback deferred from performSetHeldCallAction
     for (NSString *sessionId in self.activeCalls) {
         NSNumber *pendingHold = self.activeCalls[sessionId][@"pendingHoldEmit"];
         if (pendingHold != nil && [pendingHold boolValue] == YES) {
-            [self logMessage:[NSString stringWithFormat:@"didDeactivateAudioSession: emitting deferred hold for sessionId=%@", sessionId]];
             [self.activeCalls[sessionId] removeObjectForKey:@"pendingHoldEmit"];
             for (id callbackId in callbackIds[@"hold"]) {
                 NSDictionary *resultDict = @{ @"message": @"hold event called successfully", @"sessionId": sessionId };
@@ -1254,7 +1213,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     [self.commandDelegate sendPluginResult:pluginResult callbackId:self.VoIPPushCallbackId];
 }
 
-#pragma mark - PushKit Delegate Methods
+#define PushKit Delegate Methods
 - (void)pushRegistry:(PKPushRegistry *)registry didUpdatePushCredentials:(PKPushCredentials *)credentials forType:(PKPushType)type{
     if([credentials.token length] == 0) {
         [self logMessage:@"No device token!"];

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -817,12 +817,14 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     [[RTCAudioSession sharedInstance] audioSessionDidDeactivate:audioSession];
     monitorAudioRouteChange = NO;
 
-    // Restore to a passive category so any post-call audio (tones, notifications) plays
-    // through a deterministic route and doesn't double-play across session transitions.
-    RTCAudioSession *rtcSession = [RTCAudioSession sharedInstance];
-    [rtcSession lockForConfiguration];
-    [rtcSession setCategory:AVAudioSessionCategoryPlayback withOptions:0 error:nil];
-    [rtcSession unlockForConfiguration];
+    // Restore to a passive category on call end (not hold) so any post-call audio
+    // (tones, notifications) plays through a deterministic route and doesn't double-play.
+    if (self.activeCalls.count == 0) {
+        RTCAudioSession *rtcSession = [RTCAudioSession sharedInstance];
+        [rtcSession lockForConfiguration];
+        [rtcSession setCategory:AVAudioSessionCategoryPlayback withOptions:0 error:nil];
+        [rtcSession unlockForConfiguration];
+    }
 
     // Emit hold callback deferred from performSetHeldCallAction
     for (NSString *sessionId in self.activeCalls) {


### PR DESCRIPTION
Extensive changes to have Callkit take full control of the audio session and audio output.

Questions
- Should we keep `AVAudioSessionCategoryOptionMixWithOthers` that allow Callkit to have the ongoing audio/video call play on top of w/e is playing at the moment (music, video, etc)

setupAudioSession:
- Now uses RTCAudioSession that iosrtc/WebRTC provides, has a lock and is an useful abstraction layer
- Configures the category to be something modern
  - Only uses option `AVAudioSessionCategoryOptionAllowBluetoothHFP` which allows input/output, since `AllowBluetooth` is deprecated, `AllowAirPlay` doesn't have a mic (TV, Siri), and `BluetoothA2DP` is [only output and has no input](https://medium.com/@mehsamadi/understanding-avaudiosession-routes-on-ios-7718d934d0c0).
- Configures the mode to be different for Audio vs Video calls, it should affect if earpiece vs speaker is chosen first

Others:
- Save speaker state, apply it back when a device has been unplugged
   - Speaker -> Plug in Headphones -> Audio through headphones -> unplug headphones -> Speaker (otherwise would default back to earpiece for Audio Calls)
- Remove `updateProviderConfig`, only update the respective value when changing it, update everything when changing appName