### PR TITLE
Make iOS audio output better

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-callkit",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Cordova plugin that lets you use iOS CallKit UI (with PushKit) and Android ConnectionService UI",
   "cordova": {
     "id": "cordova-plugin-callkit",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="cordova-plugin-callkit" version="2.0.1" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="cordova-plugin-callkit" version="2.1.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>Cordova CallKit</name>
 
     <js-module name="VoIPPushNotification" src="www/VoIPPushNotification.js">

--- a/src/ios/CordovaCall.h
+++ b/src/ios/CordovaCall.h
@@ -19,6 +19,7 @@
 
 - (void)updateProviderConfig;
 - (void)setupAudioSession;
+- (void)teardownAudioSession;
 
 - (void)setAppName:(CDVInvokedUrlCommand*)command;
 - (void)setIcon:(CDVInvokedUrlCommand*)command;

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -129,8 +129,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         AVAudioSession *sessionInstance = [AVAudioSession sharedInstance];
         NSError *categoryError = nil;
         BOOL categoryConfigured = [sessionInstance setCategory:AVAudioSessionCategoryPlayAndRecord
-                                                   withOptions:AVAudioSessionCategoryOptionMixWithOthers
-                                                              | AVAudioSessionCategoryOptionAllowBluetooth
+                                                   withOptions: AVAudioSessionCategoryOptionAllowBluetooth
                                                               | AVAudioSessionCategoryOptionAllowAirPlay
                                                               | AVAudioSessionCategoryOptionAllowBluetoothA2DP
                                                          error:&categoryError];
@@ -139,7 +138,8 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         }
 
         NSError *modeError = nil;
-        BOOL modeConfigured = [sessionInstance setMode:AVAudioSessionModeVoiceChat error:&modeError];
+        BOOL modeConfigured = [sessionInstance setMode:hasVideo ? AVAudioSessionModeVideoChat : AVAudioSessionModeVoiceChat
+                                     error:&modeError];
         if (!modeConfigured) {
             [self logMessage:[NSString stringWithFormat:@"Failed to set audio session mode: %@", modeError]];
         }
@@ -1335,7 +1335,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     [self.commandDelegate sendPluginResult:pluginResult callbackId:self.VoIPPushCallbackId];
 }
 
-#define PushKit Delegate Methods
+#pragma mark PushKit Delegate Methods
 - (void)pushRegistry:(PKPushRegistry *)registry didUpdatePushCredentials:(PKPushCredentials *)credentials forType:(PKPushType)type{
     if([credentials.token length] == 0) {
         [self logMessage:@"No device token!"];

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -149,6 +149,30 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     }
 }
 
+- (void)teardownAudioSession
+{
+    @try {
+        AVAudioSession *sessionInstance = [AVAudioSession sharedInstance];
+        NSError *categoryError = nil;
+        BOOL categoryConfigured = [sessionInstance setCategory:AVAudioSessionCategoryPlayback
+                                                   withOptions:AVAudioSessionCategoryOptionMixWithOthers
+                                                         error:&categoryError];
+        if (!categoryConfigured) {
+            [self logMessage:[NSString stringWithFormat:@"Failed to reset audio session category: %@", categoryError]];
+        }
+
+        NSError *modeError = nil;
+        BOOL modeConfigured = [sessionInstance setMode:AVAudioSessionModeDefault error:&modeError];
+        if (!modeConfigured) {
+            [self logMessage:[NSString stringWithFormat:@"Failed to reset audio session mode: %@", modeError]];
+        }
+        [self logMessage:@"teardownAudioSession: audio session reset to Playback/MixWithOthers/Default"];
+    }
+    @catch (NSException *exception) {
+        [self logMessage:@"Unknown error returned from teardownAudioSession"];
+    }
+}
+
 - (void)setAppName:(CDVInvokedUrlCommand*)command
 {
     CDVPluginResult* pluginResult = nil;
@@ -903,6 +927,12 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         }
         [self rejectPendingCommandsForSessionId:sessionId];
         [self.activeCalls removeObjectForKey:sessionId];
+    }
+
+    // Once all calls have ended, reset the audio session to a mixing-friendly state
+    // so subsequent media playback behaves normally and getAudioRoute reflects reality.
+    if (self.callController.callObserver.calls.count == 0) {
+        [self teardownAudioSession];
     }
 }
 

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -32,6 +32,12 @@ NSMutableArray* pendingCallResponses;
 NSString* const PENDING_RESPONSE_ANSWER = @"pendingResponseAnswer";
 NSString* const PENDING_RESPONSE_REJECT = @"pendingResponseReject";
 
+// Saved audio session state captured before setupAudioSession; restored in teardownAudioSession.
+AVAudioSessionCategory _savedAudioCategory;
+AVAudioSessionMode _savedAudioMode;
+AVAudioSessionCategoryOptions _savedAudioCategoryOptions = 0;
+BOOL _audioSessionStateSaved = NO;
+
 NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 
 - (void)pluginInitialize
@@ -127,6 +133,18 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 {
     @try {
         AVAudioSession *sessionInstance = [AVAudioSession sharedInstance];
+
+        // Capture the host app's audio session state the first time we configure it for a call,
+        // so teardownAudioSession can restore exactly what was there before.
+        @synchronized(self) {
+            if (!_audioSessionStateSaved) {
+                _savedAudioCategory = sessionInstance.category;
+                _savedAudioMode = sessionInstance.mode;
+                _savedAudioCategoryOptions = sessionInstance.categoryOptions;
+                _audioSessionStateSaved = YES;
+            }
+        }
+
         NSError *categoryError = nil;
         BOOL categoryConfigured = [sessionInstance setCategory:AVAudioSessionCategoryPlayAndRecord
                                                    withOptions: AVAudioSessionCategoryOptionAllowBluetooth
@@ -153,20 +171,32 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 {
     @try {
         AVAudioSession *sessionInstance = [AVAudioSession sharedInstance];
+
+        // Restore whatever category/options/mode the host app had before the call began.
+        AVAudioSessionCategory categoryToRestore = _audioSessionStateSaved ? _savedAudioCategory : AVAudioSessionCategoryPlayback;
+        AVAudioSessionCategoryOptions optionsToRestore = _audioSessionStateSaved ? _savedAudioCategoryOptions : AVAudioSessionCategoryOptionMixWithOthers;
+        AVAudioSessionMode modeToRestore = _audioSessionStateSaved ? _savedAudioMode : AVAudioSessionModeDefault;
+
         NSError *categoryError = nil;
-        BOOL categoryConfigured = [sessionInstance setCategory:AVAudioSessionCategoryPlayback
-                                                   withOptions:AVAudioSessionCategoryOptionMixWithOthers
+        BOOL categoryConfigured = [sessionInstance setCategory:categoryToRestore
+                                                   withOptions:optionsToRestore
                                                          error:&categoryError];
         if (!categoryConfigured) {
             [self logMessage:[NSString stringWithFormat:@"Failed to reset audio session category: %@", categoryError]];
         }
 
         NSError *modeError = nil;
-        BOOL modeConfigured = [sessionInstance setMode:AVAudioSessionModeDefault error:&modeError];
+        BOOL modeConfigured = [sessionInstance setMode:modeToRestore error:&modeError];
         if (!modeConfigured) {
             [self logMessage:[NSString stringWithFormat:@"Failed to reset audio session mode: %@", modeError]];
         }
-        [self logMessage:@"teardownAudioSession: audio session reset to Playback/MixWithOthers/Default"];
+        [self logMessage:[NSString stringWithFormat:@"teardownAudioSession: audio session restored to %@/%@ (options: %lu)", categoryToRestore, modeToRestore, (unsigned long)optionsToRestore]];
+
+        // Clear the saved state so the next call captures a fresh snapshot.
+        _audioSessionStateSaved = NO;
+        _savedAudioCategory = nil;
+        _savedAudioMode = nil;
+        _savedAudioCategoryOptions = 0;
     }
     @catch (NSException *exception) {
         [self logMessage:@"Unknown error returned from teardownAudioSession"];


### PR DESCRIPTION
Have iosrtc cede control of the Audio Session to Callkit, where we're now responsible for setup and teardown of the audio session.

Remove "mix with others" category as that was a hack on iosrtc since it couldn't take sole control of the audio session
Set the mode for AudioCall vs VideoCall, where it sets the default audio output to be earpiece and speaker respectively
Add audio session teardown logic once all of the calls end, the audio session is set up again when we answer/make a call.