### PR TITLE
Fix move my call and incoming calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-callkit",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Cordova plugin that lets you use iOS CallKit UI (with PushKit) and Android ConnectionService UI",
   "cordova": {
     "id": "cordova-plugin-callkit",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="cordova-plugin-callkit" version="2.1.1" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="cordova-plugin-callkit" version="2.2.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>Cordova CallKit</name>
 
     <js-module name="VoIPPushNotification" src="www/VoIPPushNotification.js">

--- a/src/android/CallAudioService.java
+++ b/src/android/CallAudioService.java
@@ -1,6 +1,7 @@
 package com.dmarc.cordovacall;
 
 import android.app.Notification;
+import android.app.NotificationManager;
 import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
@@ -18,6 +19,18 @@ import androidx.core.app.ServiceCompat;
  */
 public class CallAudioService extends Service {
     private static final String TAG = "CallAudioService";
+    private static int currentNotificationId = -1;
+
+    public static int getCurrentNotificationId() {
+        return currentNotificationId;
+    }
+
+    public static void updateNotification(Context context, String peerName, String sessionId) {
+        if (currentNotificationId == -1) return;
+        Notification updated = new OngoingCallNotification(context, peerName, sessionId).build();
+        NotificationManager nm = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+        nm.notify(currentNotificationId, updated);
+    }
 
     // onStartCommand is called in response to the startService() intent
     @Override
@@ -39,6 +52,7 @@ public class CallAudioService extends Service {
 
         Notification notification = onGoingCallNotification.build();
         int notificationID = onGoingCallNotification.getNotificationID();
+        currentNotificationId = notificationID;
 
         // For Android 14 (API 34) and above, you MUST specify types in code
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
@@ -69,6 +83,8 @@ public class CallAudioService extends Service {
     @Override
     public void onDestroy() {
         Log.d(TAG, "onDestroy()");
+
+        currentNotificationId = -1;
 
         Log.d(TAG, "Returning audio mode to MODE_NORMAL");
         AudioManager audioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);

--- a/src/android/CallConnection.java
+++ b/src/android/CallConnection.java
@@ -78,6 +78,12 @@ class CallConnection extends Connection {
         LocalBroadcastManager.getInstance(service.getApplicationContext()).sendBroadcast(intent);
     }
 
+    void updatePeerName(String newPeerName) {
+        this.peerName = newPeerName;
+        setCallerDisplayName(newPeerName, android.telecom.TelecomManager.PRESENTATION_ALLOWED);
+        CallAudioService.updateNotification(service.getApplicationContext(), newPeerName, this.sessionId);
+    }
+
     protected void startCallAudioService() {
         // NOTE: CallAudioService should be started before mic access, in order to work.
         // IMPORTANT: This preserves the ability to use the mic when the app is in the background!

--- a/src/android/CallConnection.java
+++ b/src/android/CallConnection.java
@@ -80,7 +80,6 @@ class CallConnection extends Connection {
 
     void updatePeerName(String newPeerName) {
         this.peerName = newPeerName;
-        setCallerDisplayName(newPeerName, android.telecom.TelecomManager.PRESENTATION_ALLOWED);
         CallAudioService.updateNotification(service.getApplicationContext(), newPeerName, this.sessionId);
     }
 

--- a/src/android/CordovaCall.java
+++ b/src/android/CordovaCall.java
@@ -363,6 +363,25 @@ public class CordovaCall extends CordovaPlugin {
             }
             callbackContext.success();
             return true;
+        } else if (action.equals("updateCallDetails")) {
+            String sessionId = args.getString(0);
+            String callName = args.isNull(1) ? null : args.getString(1);
+            String callId = args.isNull(2) ? null : args.getString(2);
+            Connection conn = MyConnectionService.getConnection(sessionId);
+            if (conn == null) {
+                this.callbackContext.success("No call exists for the given sessionId");
+            } else if (callName == null && callId == null) {
+                this.callbackContext.error("callName or callId must be provided");
+            } else {
+                if (callName != null) {
+                    conn.setCallerDisplayName(callName, TelecomManager.PRESENTATION_ALLOWED);
+                }
+                if (callId != null) {
+                    conn.setAddress(Uri.fromParts("tel", callId, null), TelecomManager.PRESENTATION_ALLOWED);
+                }
+                this.callbackContext.success("Call details updated successfully");
+            }
+            return true;
         }
         return false;
     }

--- a/src/android/CordovaCall.java
+++ b/src/android/CordovaCall.java
@@ -374,7 +374,7 @@ public class CordovaCall extends CordovaPlugin {
             if (conn == null) {
                 this.callbackContext.success("No call exists for the given sessionId");
             } else {
-                conn.setCallerDisplayName(callName, TelecomManager.PRESENTATION_ALLOWED);
+                conn.updatePeerName(callName);
                 this.callbackContext.success("Call name updated successfully");
             }
             return true;

--- a/src/android/CordovaCall.java
+++ b/src/android/CordovaCall.java
@@ -363,23 +363,19 @@ public class CordovaCall extends CordovaPlugin {
             }
             callbackContext.success();
             return true;
-        } else if (action.equals("updateCallDetails")) {
+        } else if (action.equals("updateCallName")) {
             String sessionId = args.getString(0);
             String callName = args.isNull(1) ? null : args.getString(1);
-            String callId = args.isNull(2) ? null : args.getString(2);
+            if (callName == null) {
+                this.callbackContext.success("No callName provided, nothing to update");
+                return true;
+            }
             Connection conn = MyConnectionService.getConnection(sessionId);
             if (conn == null) {
                 this.callbackContext.success("No call exists for the given sessionId");
-            } else if (callName == null && callId == null) {
-                this.callbackContext.error("callName or callId must be provided");
             } else {
-                if (callName != null) {
-                    conn.setCallerDisplayName(callName, TelecomManager.PRESENTATION_ALLOWED);
-                }
-                if (callId != null) {
-                    conn.setAddress(Uri.fromParts("tel", callId, null), TelecomManager.PRESENTATION_ALLOWED);
-                }
-                this.callbackContext.success("Call details updated successfully");
+                conn.setCallerDisplayName(callName, TelecomManager.PRESENTATION_ALLOWED);
+                this.callbackContext.success("Call name updated successfully");
             }
             return true;
         }

--- a/src/android/IncomingCallConnection.java
+++ b/src/android/IncomingCallConnection.java
@@ -78,6 +78,12 @@ class IncomingCallConnection extends CallConnection {
     }
 
     @Override
+    void updatePeerName(String newPeerName) {
+        super.updatePeerName(newPeerName);
+        setCallerDisplayName(newPeerName, android.telecom.TelecomManager.PRESENTATION_ALLOWED);
+    }
+
+    @Override
     public void onStateChanged(int state) {
         if (state == Connection.STATE_ACTIVE) {
             // For an incoming call specifically, we wait for the connection to be ACTIVE as this would

--- a/src/ios/CordovaCall.h
+++ b/src/ios/CordovaCall.h
@@ -31,7 +31,7 @@
 - (void)receiveCall:(CDVInvokedUrlCommand*)command;
 - (void)sendCall:(CDVInvokedUrlCommand*)command;
 - (void)connectCall:(CDVInvokedUrlCommand*)command;
-- (void)updateCallDetails:(CDVInvokedUrlCommand*)command;
+- (void)updateCallName:(CDVInvokedUrlCommand*)command;
 - (void)endCall:(CDVInvokedUrlCommand*)command;
 - (void)registerEvent:(CDVInvokedUrlCommand*)command;
 - (void)mute:(CDVInvokedUrlCommand*)command;

--- a/src/ios/CordovaCall.h
+++ b/src/ios/CordovaCall.h
@@ -31,6 +31,7 @@
 - (void)receiveCall:(CDVInvokedUrlCommand*)command;
 - (void)sendCall:(CDVInvokedUrlCommand*)command;
 - (void)connectCall:(CDVInvokedUrlCommand*)command;
+- (void)updateCallDetails:(CDVInvokedUrlCommand*)command;
 - (void)endCall:(CDVInvokedUrlCommand*)command;
 - (void)registerEvent:(CDVInvokedUrlCommand*)command;
 - (void)mute:(CDVInvokedUrlCommand*)command;

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -395,31 +395,28 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
-- (void)updateCallDetails:(CDVInvokedUrlCommand*)command
+- (void)updateCallName:(CDVInvokedUrlCommand*)command
 {
-    [self logMessage:@"updateCallDetails"];
+    [self logMessage:@"updateCallName"];
     NSString* sessionId = [command.arguments objectAtIndex:0];
     id callNameArg = [command.arguments objectAtIndex:1];
     NSString* callName = ([callNameArg isKindOfClass:[NSString class]] && [callNameArg length] > 0) ? callNameArg : nil;
-    id callIdArg = [command.arguments objectAtIndex:2];
-    NSString* callId = [callIdArg isKindOfClass:[NSString class]] ? callIdArg : nil;
-    CXCall *call = [self callForSessionId:sessionId];
     CDVPluginResult* pluginResult = nil;
 
-    if (call && (callName || callId)) {
+    if (!callName) {
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"No callName provided, nothing to update"];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+        return;
+    }
+
+    CXCall *call = [self callForSessionId:sessionId];
+    if (call) {
         CXCallUpdate *update = [[CXCallUpdate alloc] init];
-        if (callName) {
-            update.localizedCallerName = callName;
-        }
-        if (callId) {
-            update.remoteHandle = [[CXHandle alloc] initWithType:CXHandleTypePhoneNumber value:callId];
-        }
+        update.localizedCallerName = callName;
         [self.provider reportCallWithUUID:call.UUID updated:update];
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Call details updated successfully"];
-    } else if (!call) {
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"No call exists for the given sessionId"];
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Call name updated successfully"];
     } else {
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"callName or callId must be provided"];
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"No call exists for the given sessionId"];
     }
 
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -1490,7 +1490,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     NSString *from = [fromValue isKindOfClass:[NSString class]] && [fromValue length] > 0 ? fromValue : nil;
     id callIdValue = [[[payloadObj valueForKey:@"cid"] componentsSeparatedByCharactersInSet:[[NSCharacterSet decimalDigitCharacterSet] invertedSet]] componentsJoinedByString:@""];
     NSString *callId = [callIdValue isKindOfClass:[NSString class]] ? callIdValue : nil;
-    NSArray* args = [NSArray arrayWithObjects:from, callId, sessionId, nil];
+    NSArray* args = @[from ?: [NSNull null], callId ?: [NSNull null], sessionId];
     CDVInvokedUrlCommand* newCommand = [[CDVInvokedUrlCommand alloc] initWithArguments:args callbackId:@"" className:self.VoIPPushClassName methodName:self.VoIPPushMethodName];
 
     // Store URL and Call Id so they can be used for call Answer/Reject

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -284,7 +284,13 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     [self logMessage:@"receiveCall"];
     BOOL hasId = ![[command.arguments objectAtIndex:1] isEqual:[NSNull null]];
     NSString* callName = [command.arguments objectAtIndex:0];
+    if (![callName isKindOfClass:[NSString class]] || [callName length] == 0) {
+        callName = nil;
+    }
     NSString* callId = hasId?[command.arguments objectAtIndex:1]:callName;
+    if (callId == nil) {
+        callId = @"Unknown";
+    }
     NSString* sessionId = [command.arguments objectAtIndex:2];
     // We must always be provided a sessionId because we need to identify the call
     if (sessionId == nil) {
@@ -304,50 +310,52 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         [[NSUserDefaults standardUserDefaults] synchronize];
     }
 
-    if (callName != nil && [callName length] > 0) {
-        CXHandle *handle = [[CXHandle alloc] initWithType:CXHandleTypePhoneNumber value:callId];
-        CXCallUpdate *callUpdate = [[CXCallUpdate alloc] init];
-        callUpdate.remoteHandle = handle;
-        callUpdate.hasVideo = hasVideo;
-        callUpdate.localizedCallerName = callName;
-        callUpdate.supportsGrouping = NO;
-        callUpdate.supportsUngrouping = NO;
-        callUpdate.supportsHolding = YES;
-        callUpdate.supportsDTMF = enableDTMF;
-        [self.provider reportNewIncomingCallWithUUID:callUUID update:callUpdate completion:^(NSError * _Nullable error) {
-            if(error == nil) {
-                // If a dismiss arrived while reportNewIncomingCallWithUUID was in-flight,
-                // end the call immediately now that CallKit has registered it.
-                // This prevents the dismiss being silently dropped during cold launch.
-                if ([self.activeCalls[sessionId][@"pendingDismiss"] boolValue]) {
-                    [self logMessage:[NSString stringWithFormat:@"receiveCall completion: pendingDismiss set, ending call for sessionId: %@", sessionId]];
-                    [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Incoming call dismissed before answer"] callbackId:command.callbackId];
-                    [self _dismissRingingCall:sessionId];
-                } else {
-                    [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Incoming call successful"] callbackId:command.callbackId];
-                }
+    CXHandle *handle = [[CXHandle alloc] initWithType:CXHandleTypePhoneNumber value:callId];
+    CXCallUpdate *callUpdate = [[CXCallUpdate alloc] init];
+    callUpdate.remoteHandle = handle;
+    callUpdate.hasVideo = hasVideo;
+    callUpdate.localizedCallerName = callName;
+    callUpdate.supportsGrouping = NO;
+    callUpdate.supportsUngrouping = NO;
+    callUpdate.supportsHolding = YES;
+    callUpdate.supportsDTMF = enableDTMF;
+    [self.provider reportNewIncomingCallWithUUID:callUUID update:callUpdate completion:^(NSError * _Nullable error) {
+        if(error == nil) {
+            // If a dismiss arrived while reportNewIncomingCallWithUUID was in-flight,
+            // end the call immediately now that CallKit has registered it.
+            // This prevents the dismiss being silently dropped during cold launch.
+            if ([self.activeCalls[sessionId][@"pendingDismiss"] boolValue]) {
+                [self logMessage:[NSString stringWithFormat:@"receiveCall completion: pendingDismiss set, ending call for sessionId: %@", sessionId]];
+                [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Incoming call dismissed before answer"] callbackId:command.callbackId];
+                [self _dismissRingingCall:sessionId];
             } else {
-                [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:[error localizedDescription]] callbackId:command.callbackId];
-                return;
+                [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Incoming call successful"] callbackId:command.callbackId];
             }
-        }];
-        for (id callbackId in callbackIds[@"receiveCall"]) {
-            CDVPluginResult* pluginResult = nil;
-            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"receiveCall event called successfully"];
-            [pluginResult setKeepCallbackAsBool:YES];
-            [self.commandDelegate sendPluginResult:pluginResult callbackId:callbackId];
+        } else {
+            [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:[error localizedDescription]] callbackId:command.callbackId];
+            return;
         }
-    } else {
-        [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Caller id can't be empty"] callbackId:command.callbackId];
+    }];
+    for (id callbackId in callbackIds[@"receiveCall"]) {
+        CDVPluginResult* pluginResult = nil;
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"receiveCall event called successfully"];
+        [pluginResult setKeepCallbackAsBool:YES];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:callbackId];
     }
 }
 
 - (void)sendCall:(CDVInvokedUrlCommand*)command
 {
     [self logMessage:@"sendCall"];
-    BOOL hasId = ![[command.arguments objectAtIndex:1] isEqual:[NSNull null]];
     NSString* callName = [command.arguments objectAtIndex:0];
-    NSString* callId = hasId?[command.arguments objectAtIndex:1]:callName;
+    if (![callName isKindOfClass:[NSString class]] || [callName length] == 0) {
+        callName = nil;
+    }
+    BOOL hasId = ![[command.arguments objectAtIndex:1] isEqual:[NSNull null]];
+    NSString* callId = hasId ? [command.arguments objectAtIndex:1] : callName;
+    if (callId == nil) {
+        callId = @"Unknown";
+    }
     NSString* sessionId = [command.arguments objectAtIndex:2];
     NSUUID *callUUID = [[NSUUID alloc] init];
     self.activeCalls[sessionId] = [self newActiveCallEntryWithUUID:callUUID];
@@ -357,22 +365,18 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         [[NSUserDefaults standardUserDefaults] synchronize];
     }
 
-    if (callName != nil && [callName length] > 0) {
-        CXHandle *handle = [[CXHandle alloc] initWithType:CXHandleTypePhoneNumber value:callId];
-        CXStartCallAction *startCallAction = [[CXStartCallAction alloc] initWithCallUUID:callUUID handle:handle];
-        startCallAction.contactIdentifier = callName;
-        startCallAction.video = hasVideo;
-        CXTransaction *transaction = [[CXTransaction alloc] initWithAction:startCallAction];
-        [self.callController requestTransaction:transaction completion:^(NSError * _Nullable error) {
-            if (error == nil) {
-                self.activeCalls[sessionId][@"callbackMap"][startCallAction.UUID.UUIDString] = [@{ @"callbackId": command.callbackId, @"event": @"sendCall" } mutableCopy];
-            } else {
-                [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:[error localizedDescription]] callbackId:command.callbackId];
-            }
-        }];
-    } else {
-        [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"The caller id can't be empty"] callbackId:command.callbackId];
-    }
+    CXHandle *handle = [[CXHandle alloc] initWithType:CXHandleTypePhoneNumber value:callId];
+    CXStartCallAction *startCallAction = [[CXStartCallAction alloc] initWithCallUUID:callUUID handle:handle];
+    startCallAction.contactIdentifier = callName;
+    startCallAction.video = hasVideo;
+    CXTransaction *transaction = [[CXTransaction alloc] initWithAction:startCallAction];
+    [self.callController requestTransaction:transaction completion:^(NSError * _Nullable error) {
+        if (error == nil) {
+            self.activeCalls[sessionId][@"callbackMap"][startCallAction.UUID.UUIDString] = [@{ @"callbackId": command.callbackId, @"event": @"sendCall" } mutableCopy];
+        } else {
+            [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:[error localizedDescription]] callbackId:command.callbackId];
+        }
+    }];
 }
 
 - (void)connectCall:(CDVInvokedUrlCommand*)command
@@ -396,6 +400,36 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Call connected successfully"];
     } else {
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"No call exists for you to connect"];
+    }
+
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
+- (void)updateCallDetails:(CDVInvokedUrlCommand*)command
+{
+    [self logMessage:@"updateCallDetails"];
+    NSString* sessionId = [command.arguments objectAtIndex:0];
+    id callNameArg = [command.arguments objectAtIndex:1];
+    NSString* callName = ([callNameArg isKindOfClass:[NSString class]] && [callNameArg length] > 0) ? callNameArg : nil;
+    id callIdArg = [command.arguments objectAtIndex:2];
+    NSString* callId = [callIdArg isKindOfClass:[NSString class]] ? callIdArg : nil;
+    CXCall *call = [self callForSessionId:sessionId];
+    CDVPluginResult* pluginResult = nil;
+
+    if (call && (callName || callId)) {
+        CXCallUpdate *update = [[CXCallUpdate alloc] init];
+        if (callName) {
+            update.localizedCallerName = callName;
+        }
+        if (callId) {
+            update.remoteHandle = [[CXHandle alloc] initWithType:CXHandleTypePhoneNumber value:callId];
+        }
+        [self.provider reportCallWithUUID:call.UUID updated:update];
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Call details updated successfully"];
+    } else if (!call) {
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"No call exists for the given sessionId"];
+    } else {
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"callName or callId must be provided"];
     }
 
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
@@ -1136,10 +1170,10 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 - (void)_reportAndEndDummyCall {
     [self logMessage:@"_reportAndEndDummyCall: reporting dummy call for malformed VoIP push"];
     NSUUID *dummyUUID = [[NSUUID alloc] init];
-    CXHandle *handle = [[CXHandle alloc] initWithType:CXHandleTypePhoneNumber value:@"unknown"];
+    CXHandle *handle = [[CXHandle alloc] initWithType:CXHandleTypePhoneNumber value:@"Unknown"];
     CXCallUpdate *callUpdate = [[CXCallUpdate alloc] init];
     callUpdate.remoteHandle = handle;
-    callUpdate.localizedCallerName = @"Unknown";
+    callUpdate.localizedCallerName = nil;
     [self.provider reportNewIncomingCallWithUUID:dummyUUID update:callUpdate completion:^(NSError * _Nullable error) {
         if (error != nil) {
             [self logMessage:[NSString stringWithFormat:@"_reportAndEndDummyCall: failed to report dummy incoming call: %@", error.localizedDescription]];
@@ -1466,8 +1500,10 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         return;
     }
     id fromValue = [payloadObj valueForKey:@"from"];
-    NSString *from = [fromValue isKindOfClass:[NSString class]] && [fromValue length] > 0 ? fromValue : @"Unknown";
-    NSArray* args = [NSArray arrayWithObjects:from, [NSNull null], sessionId, nil];
+    NSString *from = [fromValue isKindOfClass:[NSString class]] && [fromValue length] > 0 ? fromValue : nil;
+    id callIdValue = [[[payloadObj valueForKey:@"cid"] componentsSeparatedByCharactersInSet:[[NSCharacterSet decimalDigitCharacterSet] invertedSet]] componentsJoinedByString:@""];
+    NSString *callId = [callIdValue isKindOfClass:[NSString class]] ? callIdValue : nil;
+    NSArray* args = [NSArray arrayWithObjects:from, callId, sessionId, nil];
     CDVInvokedUrlCommand* newCommand = [[CDVInvokedUrlCommand alloc] initWithArguments:args callbackId:@"" className:self.VoIPPushClassName methodName:self.VoIPPushMethodName];
 
     // Store URL and Call Id so they can be used for call Answer/Reject

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -305,11 +305,6 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     }
     NSUUID *callUUID = self.activeCalls[sessionId][@"callUUID"];
 
-    if (hasId) {
-        [[NSUserDefaults standardUserDefaults] setObject:callName forKey:[command.arguments objectAtIndex:1]];
-        [[NSUserDefaults standardUserDefaults] synchronize];
-    }
-
     CXHandle *handle = [[CXHandle alloc] initWithType:CXHandleTypePhoneNumber value:callId];
     CXCallUpdate *callUpdate = [[CXCallUpdate alloc] init];
     callUpdate.remoteHandle = handle;
@@ -359,11 +354,6 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     NSString* sessionId = [command.arguments objectAtIndex:2];
     NSUUID *callUUID = [[NSUUID alloc] init];
     self.activeCalls[sessionId] = [self newActiveCallEntryWithUUID:callUUID];
-
-    if (hasId) {
-        [[NSUserDefaults standardUserDefaults] setObject:callName forKey:[command.arguments objectAtIndex:1]];
-        [[NSUserDefaults standardUserDefaults] synchronize];
-    }
 
     CXHandle *handle = [[CXHandle alloc] initWithType:CXHandleTypePhoneNumber value:callId];
     CXStartCallAction *startCallAction = [[CXStartCallAction alloc] initWithCallUUID:callUUID handle:handle];
@@ -855,7 +845,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     NSString *recentsSessionId = [NSString stringWithFormat:@"recents:%@", action.handle.value];
     BOOL isRecentsCall = self.activeCalls[recentsSessionId] != nil;
     // Store the sendCall payload; it will be emitted in didActivateAudioSession via pendingActivateAudioSessionEmits.
-    pendingStartCallData = @{@"callName":action.contactIdentifier, @"callId": action.handle.value, @"isVideo": action.video?@YES:@NO, @"message": @"sendCall event called successfully", @"recentsSessionId": isRecentsCall ? recentsSessionId : [NSNull null]};
+    pendingStartCallData = @{@"callName":action.contactIdentifier ?: action.handle.value ?: @"", @"callId": action.handle.value ?: @"", @"isVideo": action.video?@YES:@NO, @"message": @"sendCall event called successfully", @"recentsSessionId": isRecentsCall ? recentsSessionId : [NSNull null]};
     NSString *sessionId = [self sessionIdForUUID:action.callUUID];
     if (sessionId) {
         [self.activeCalls[sessionId][@"pendingActivateAudioSessionEmits"] addObject:@{@"uuid": action.UUID.UUIDString, @"type": @"sendCall"}];

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -348,7 +348,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     }
     BOOL hasId = ![[command.arguments objectAtIndex:1] isEqual:[NSNull null]];
     NSString* callId = hasId ? [command.arguments objectAtIndex:1] : callName;
-    if (callId == nil) {
+    if (![callId isKindOfClass:[NSString class]] || [callId length] == 0) {
         callId = @"Unknown";
     }
     NSString* sessionId = [command.arguments objectAtIndex:2];

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -1488,8 +1488,12 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     }
     id fromValue = [payloadObj valueForKey:@"from"];
     NSString *from = [fromValue isKindOfClass:[NSString class]] && [fromValue length] > 0 ? fromValue : nil;
-    id callIdValue = [[[payloadObj valueForKey:@"cid"] componentsSeparatedByCharactersInSet:[[NSCharacterSet decimalDigitCharacterSet] invertedSet]] componentsJoinedByString:@""];
-    NSString *callId = [callIdValue isKindOfClass:[NSString class]] ? callIdValue : nil;
+    id cidValue = [payloadObj valueForKey:@"cid"];
+    NSString *callId = nil;
+    if ([cidValue isKindOfClass:[NSString class]]) {
+        NSString *sanitizedCallId = [[cidValue componentsSeparatedByCharactersInSet:[[NSCharacterSet decimalDigitCharacterSet] invertedSet]] componentsJoinedByString:@""];
+        callId = sanitizedCallId.length > 0 ? sanitizedCallId : nil;
+    }
     NSArray* args = @[from ?: [NSNull null], callId ?: [NSNull null], sessionId];
     CDVInvokedUrlCommand* newCommand = [[CDVInvokedUrlCommand alloc] initWithArguments:args callbackId:@"" className:self.VoIPPushClassName methodName:self.VoIPPushMethodName];
 

--- a/www/CordovaCall.js
+++ b/www/CordovaCall.js
@@ -83,6 +83,10 @@ exports.connectCall = function (sessionId, recentsSessionId, success, error) {
   exec(success, error, "CordovaCall", "connectCall", [sessionId, recentsSessionId || null]);
 };
 
+exports.updateCallDetails = function (sessionId, callName, callId, success, error) {
+  exec(success, error, "CordovaCall", "updateCallDetails", [sessionId, callName || null, callId || null]);
+};
+
 exports.endCall = function (sessionId, success, error) {
   exec(success, error, "CordovaCall", "endCall", [sessionId]);
 };

--- a/www/CordovaCall.js
+++ b/www/CordovaCall.js
@@ -83,8 +83,8 @@ exports.connectCall = function (sessionId, recentsSessionId, success, error) {
   exec(success, error, "CordovaCall", "connectCall", [sessionId, recentsSessionId || null]);
 };
 
-exports.updateCallDetails = function (sessionId, callName, callId, success, error) {
-  exec(success, error, "CordovaCall", "updateCallDetails", [sessionId, callName || null, callId || null]);
+exports.updateCallName = function (sessionId, callName, success, error) {
+  exec(success, error, "CordovaCall", "updateCallName", [sessionId, callName || null]);
 };
 
 exports.endCall = function (sessionId, success, error) {


### PR DESCRIPTION
- Allow passing in empty callName or callId for iOS
  - `callName = nil` apparently does "Unknown Caller" on iOS
  - callId cannot be nil so default to "Unknown"
- Allow editing the `callName` for an ongoing call
- Fix incoming calls for iOS, pass along the `cid` as `callId` so "call from recents" will work