### PR TITLE
fix conn.updatePeerName

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-callkit",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Cordova plugin that lets you use iOS CallKit UI (with PushKit) and Android ConnectionService UI",
   "cordova": {
     "id": "cordova-plugin-callkit",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="cordova-plugin-callkit" version="2.2.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="cordova-plugin-callkit" version="2.2.1" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>Cordova CallKit</name>
 
     <js-module name="VoIPPushNotification" src="www/VoIPPushNotification.js">

--- a/src/android/CordovaCall.java
+++ b/src/android/CordovaCall.java
@@ -373,8 +373,8 @@ public class CordovaCall extends CordovaPlugin {
             Connection conn = MyConnectionService.getConnection(sessionId);
             if (conn == null) {
                 this.callbackContext.success("No call exists for the given sessionId");
-            } else {
-                conn.updatePeerName(callName);
+            } else if (conn instanceof CallConnection) {
+                ((CallConnection) conn).updatePeerName(callName);
                 this.callbackContext.success("Call name updated successfully");
             }
             return true;


### PR DESCRIPTION
Fix compile error...

```
> Task :app:compileReleaseJavaWithJavac FAILED
/Users/rexchiu/code/facetalkCordova/platforms/android/app/src/main/java/com/dmarc/cordovacall/CordovaCall.java:377: error: cannot find symbol
                conn.updatePeerName(callName);
                    ^
  symbol:   method updatePeerName(String)
  location: variable conn of type Connection
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
1 error
```