### PR TITLE
Add ability to prevent unmute for active calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-callkit",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Cordova plugin that lets you use iOS CallKit UI (with PushKit) and Android ConnectionService UI",
   "cordova": {
     "id": "cordova-plugin-callkit",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="cordova-plugin-callkit" version="2.2.2" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="cordova-plugin-callkit" version="2.2.3" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>Cordova CallKit</name>
 
     <js-module name="VoIPPushNotification" src="www/VoIPPushNotification.js">

--- a/src/android/CordovaCall.java
+++ b/src/android/CordovaCall.java
@@ -310,6 +310,9 @@ public class CordovaCall extends CordovaPlugin {
             this.unmute();
             this.callbackContext.success("Unmuted Successfully");
             return true;
+        } else if (action.equals("setAllowUnmute")) {
+            callbackContext.success();
+            return true;
         } else if (action.equals("speakerOn")) {
             this.speakerOn();
             return true;

--- a/src/android/CordovaCall.java
+++ b/src/android/CordovaCall.java
@@ -311,7 +311,7 @@ public class CordovaCall extends CordovaPlugin {
             this.callbackContext.success("Unmuted Successfully");
             return true;
         } else if (action.equals("setAllowUnmute")) {
-            callbackContext.error("setAllowUnmute is not supported on Android");
+            this.callbackContext.error("setAllowUnmute is not supported on Android");
             return true;
         } else if (action.equals("speakerOn")) {
             this.speakerOn();

--- a/src/android/CordovaCall.java
+++ b/src/android/CordovaCall.java
@@ -311,7 +311,7 @@ public class CordovaCall extends CordovaPlugin {
             this.callbackContext.success("Unmuted Successfully");
             return true;
         } else if (action.equals("setAllowUnmute")) {
-            callbackContext.success();
+            callbackContext.error("setAllowUnmute is not supported on Android");
             return true;
         } else if (action.equals("speakerOn")) {
             this.speakerOn();

--- a/src/ios/CordovaCall.h
+++ b/src/ios/CordovaCall.h
@@ -26,6 +26,7 @@
 - (void)setRingtone:(CDVInvokedUrlCommand*)command;
 - (void)setIncludeInRecents:(CDVInvokedUrlCommand*)command;
 - (void)setDTMFState:(CDVInvokedUrlCommand*)command;
+- (void)setAllowUnmute:(CDVInvokedUrlCommand*)command;
 - (void)setVideo:(CDVInvokedUrlCommand*)command;
 
 - (void)receiveCall:(CDVInvokedUrlCommand*)command;

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -289,6 +289,20 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
+- (void)setAllowUnmute:(CDVInvokedUrlCommand*)command
+{
+    NSString *sessionId = [command.arguments objectAtIndex:0];
+    BOOL value = [[command.arguments objectAtIndex:1] boolValue];
+    CDVPluginResult *pluginResult = nil;
+    if (self.activeCalls[sessionId]) {
+        self.activeCalls[sessionId][@"allowUnmute"] = @(value);
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"allowUnmute Changed Successfully"];
+    } else {
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"No active call for sessionId"];
+    }
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
 - (void)setVideo:(CDVInvokedUrlCommand*)command
 {
     CDVPluginResult* pluginResult = nil;
@@ -1113,6 +1127,27 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     }
     [self logMessage:[NSString stringWithFormat:@"CallKit performSetMutedCallAction received %@ event, sessionId: %@", isMuted ? @"mute" : @"unmute", sessionId]];
 
+    // If this is an unmute request and allowUnmute is NO for this session, fail the action.
+    BOOL allowUnmute = [self.activeCalls[sessionId][@"allowUnmute"] boolValue];
+    if (!isMuted && !allowUnmute) {
+        [self logMessage:@"performSetMutedCallAction: allowUnmute is NO, reject unmute action"];
+        // Failing the action will cause CallKit to revert the UI toggle back to "muted" state,
+        // which is the desired behavior when unmuting is disallowed.
+        NSMutableDictionary *entry = self.activeCalls[sessionId][@"callbackMap"][action.UUID.UUIDString];
+        if (entry) {
+            // UI-initiated mute/unmute: emit to event listeners only.
+            [self.activeCalls[sessionId][@"callbackMap"] removeObjectForKey:action.UUID.UUIDString];
+            NSString *cbId = entry[@"callbackId"];
+            if (cbId) {
+                NSDictionary *resultDict = @{ @"message": @"unmute not permitted", @"sessionId": sessionId };
+                CDVPluginResult *result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:resultDict];
+                [self.commandDelegate sendPluginResult:result callbackId:cbId];
+            }
+        }
+        [action fail];
+        return;
+    }
+
     [action fulfill];
 
     if (self.activeCalls[sessionId][@"callbackMap"][action.UUID.UUIDString]) {
@@ -1224,7 +1259,8 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         @"callbackMap": [NSMutableDictionary dictionary],
         @"pendingActivateAudioSessionEmits": [NSMutableArray array],
         @"pendingDeactivateAudioSessionEmits": [NSMutableArray array],
-        @"pendingDismiss": @NO
+        @"pendingDismiss": @NO,
+        @"allowUnmute": @YES
     } mutableCopy];
 }
 

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -526,10 +526,13 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         CXSetMutedCallAction *muteAction = [[CXSetMutedCallAction alloc] initWithCallUUID:call.UUID muted:YES];
         CXTransaction *transaction = [[CXTransaction alloc] initWithAction:muteAction];
         [self logMessage:[NSString stringWithFormat:@"Programmatically Muting Call: %@", sessionId]];
+        // Pre-populate callbackMap before requestTransaction: performSetMutedCallAction fires
+        // before the requestTransaction completion block, so the entry must already be present.
+        self.activeCalls[sessionId][@"callbackMap"][muteAction.UUID.UUIDString] = [@{ @"callbackId": command.callbackId, @"event": @"mute" } mutableCopy];
         [self.callController requestTransaction:transaction completion:^(NSError * _Nullable error) {
-            if (error == nil) {
-                self.activeCalls[sessionId][@"callbackMap"][muteAction.UUID.UUIDString] = [@{ @"callbackId": command.callbackId, @"event": @"mute" } mutableCopy];
-            } else {
+            if (error != nil) {
+                // Transaction was rejected before reaching performSetMutedCallAction — clean up.
+                [self.activeCalls[sessionId][@"callbackMap"] removeObjectForKey:muteAction.UUID.UUIDString];
                 [self logMessage:@"Error occurred muting Call"];
                 NSDictionary *resultDict = @{ @"message": @"An error occurred", @"sessionId": sessionId };
                 CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:resultDict];
@@ -552,10 +555,13 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         CXSetMutedCallAction *unmuteAction = [[CXSetMutedCallAction alloc] initWithCallUUID:call.UUID muted:NO];
         CXTransaction *transaction = [[CXTransaction alloc] initWithAction:unmuteAction];
         [self logMessage:[NSString stringWithFormat:@"Programmatically Unmuting Call: %@", sessionId]];
+        // Pre-populate callbackMap before requestTransaction: performSetMutedCallAction fires
+        // before the requestTransaction completion block, so the entry must already be present.
+        self.activeCalls[sessionId][@"callbackMap"][unmuteAction.UUID.UUIDString] = [@{ @"callbackId": command.callbackId, @"event": @"unmute" } mutableCopy];
         [self.callController requestTransaction:transaction completion:^(NSError * _Nullable error) {
-            if (error == nil) {
-                self.activeCalls[sessionId][@"callbackMap"][unmuteAction.UUID.UUIDString] = [@{ @"callbackId": command.callbackId, @"event": @"unmute" } mutableCopy];
-            } else {
+            if (error != nil) {
+                // Transaction was rejected before reaching performSetMutedCallAction — clean up.
+                [self.activeCalls[sessionId][@"callbackMap"] removeObjectForKey:unmuteAction.UUID.UUIDString];
                 [self logMessage:@"Error occurred unmuting Call"];
                 NSDictionary *resultDict = @{ @"message": @"An error occurred", @"sessionId": sessionId };
                 CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:resultDict];
@@ -1127,32 +1133,24 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     }
     [self logMessage:[NSString stringWithFormat:@"CallKit performSetMutedCallAction received %@ event, sessionId: %@", isMuted ? @"mute" : @"unmute", sessionId]];
 
-    // If this is an unmute request and allowUnmute is NO for this session, fail the action.
-    BOOL allowUnmute = [self.activeCalls[sessionId][@"allowUnmute"] boolValue];
-    if (!isMuted && !allowUnmute) {
-        [self logMessage:@"performSetMutedCallAction: allowUnmute is NO, reject unmute action"];
-        // Failing the action will cause CallKit to revert the UI toggle back to "muted" state,
-        // which is the desired behavior when unmuting is disallowed.
-        NSMutableDictionary *entry = self.activeCalls[sessionId][@"callbackMap"][action.UUID.UUIDString];
-        if (entry) {
-            [self.activeCalls[sessionId][@"callbackMap"] removeObjectForKey:action.UUID.UUIDString];
-            NSString *cbId = entry[@"callbackId"];
-            if (cbId) {
-                NSDictionary *resultDict = @{ @"message": @"unmute not permitted", @"sessionId": sessionId };
-                CDVPluginResult *result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:resultDict];
-                [self.commandDelegate sendPluginResult:result callbackId:cbId];
-            }
-        }
-        [action fail];
+    if (self.activeCalls[sessionId][@"callbackMap"][action.UUID.UUIDString]) {
+        [action fulfill];
+
+        // Programmatic mute/unmute: resolve the JS promise only.
+        [self resolveCommandForSessionId:sessionId actionUUIDString:action.UUID.UUIDString];
         return;
     }
 
-    [action fulfill];
+    BOOL allowUnmute = [self.activeCalls[sessionId][@"allowUnmute"] boolValue];
+    if (!isMuted && !allowUnmute) {
+        // If this is an unmute request and allowUnmute is NO for this session, fail the action.
+        [action fail];
 
-    if (self.activeCalls[sessionId][@"callbackMap"][action.UUID.UUIDString]) {
-        // Programmatic mute/unmute: resolve the JS promise only.
-        [self resolveCommandForSessionId:sessionId actionUUIDString:action.UUID.UUIDString];
+        [self logMessage:@"performSetMutedCallAction: allowUnmute is NO, reject unmute action"];
+        return;
     } else {
+        [action fulfill];
+
         // UI-initiated mute/unmute: emit to event listeners only.
         for (id callbackId in callbackIds[isMuted ? @"mute" : @"unmute"]) {
             [self logMessage:[NSString stringWithFormat:@"Sending %@ event to JS", isMuted ? @"mute" : @"unmute"]];

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -1135,7 +1135,6 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         // which is the desired behavior when unmuting is disallowed.
         NSMutableDictionary *entry = self.activeCalls[sessionId][@"callbackMap"][action.UUID.UUIDString];
         if (entry) {
-            // UI-initiated mute/unmute: emit to event listeners only.
             [self.activeCalls[sessionId][@"callbackMap"] removeObjectForKey:action.UUID.UUIDString];
             NSString *cbId = entry[@"callbackId"];
             if (cbId) {

--- a/www/CordovaCall.js
+++ b/www/CordovaCall.js
@@ -44,6 +44,14 @@ exports.setDTMFState = function (value, success, error) {
   }
 };
 
+exports.setAllowUnmute = function (sessionId, value, success, error) {
+  if (typeof value == "boolean") {
+    exec(success, error, "CordovaCall", "setAllowUnmute", [sessionId, value]);
+  } else {
+    error("Value Must Be True Or False");
+  }
+};
+
 exports.setVideo = function (value, success, error) {
   if (typeof value == "boolean") {
     exec(success, error, "CordovaCall", "setVideo", [value]);

--- a/www/CordovaCall.js
+++ b/www/CordovaCall.js
@@ -44,14 +44,6 @@ exports.setDTMFState = function (value, success, error) {
   }
 };
 
-exports.setAllowUnmute = function (sessionId, value, success, error) {
-  if (typeof value == "boolean") {
-    exec(success, error, "CordovaCall", "setAllowUnmute", [sessionId, value]);
-  } else {
-    if (typeof error == "function") { error("Value Must Be True Or False"); }
-  }
-};
-
 exports.setVideo = function (value, success, error) {
   if (typeof value == "boolean") {
     exec(success, error, "CordovaCall", "setVideo", [value]);
@@ -161,6 +153,14 @@ exports.dismissRingingCall = function (sessionId, success) {
 exports.log = function (message) {
   exec(null, null, "CordovaCall", "log", [message]);
 }
+
+exports.setAllowUnmute = function (sessionId, value, success, error) {
+  if (typeof value == "boolean") {
+    exec(success, error, "CordovaCall", "setAllowUnmute", [sessionId, value]);
+  } else {
+    if (typeof error == "function") { error("Value Must Be True Or False"); }
+  }
+};
 
 exports.keepAlive = function (callback) {
   exec(callback, null, "CordovaCall", "keepAlive", []);

--- a/www/CordovaCall.js
+++ b/www/CordovaCall.js
@@ -32,7 +32,7 @@ exports.setIncludeInRecents = function (value, success, error) {
   if (typeof value == "boolean") {
     exec(success, error, "CordovaCall", "setIncludeInRecents", [value]);
   } else {
-    error("Value Must Be True Or False");
+    if (typeof error == "function") { error("Value Must Be True Or False"); }
   }
 };
 
@@ -40,7 +40,7 @@ exports.setDTMFState = function (value, success, error) {
   if (typeof value == "boolean") {
     exec(success, error, "CordovaCall", "setDTMFState", [value]);
   } else {
-    error("Value Must Be True Or False");
+    if (typeof error == "function") { error("Value Must Be True Or False"); }
   }
 };
 
@@ -48,7 +48,7 @@ exports.setAllowUnmute = function (sessionId, value, success, error) {
   if (typeof value == "boolean") {
     exec(success, error, "CordovaCall", "setAllowUnmute", [sessionId, value]);
   } else {
-    error("Value Must Be True Or False");
+    if (typeof error == "function") { error("Value Must Be True Or False"); }
   }
 };
 
@@ -56,7 +56,7 @@ exports.setVideo = function (value, success, error) {
   if (typeof value == "boolean") {
     exec(success, error, "CordovaCall", "setVideo", [value]);
   } else {
-    error("Value Must Be True Or False");
+    if (typeof error == "function") { error("Value Must Be True Or False"); }
   }
 };
 


### PR DESCRIPTION
This pull request introduces support for controlling whether a call can be unmuted on iOS by adding an `allowUnmute` property to active calls. This allows the app to programmatically prevent users from unmuting during a call. The Android implementation does not support this feature and returns an error if called. The main changes are grouped by platform below.

**iOS: Allow Unmute Feature**

* Added a new method `setAllowUnmute` to `CordovaCall` that allows toggling whether unmuting is permitted for a specific call session. This updates the `allowUnmute` property in the active call entry. (`src/ios/CordovaCall.h`, `src/ios/CordovaCall.m`) [[1]](diffhunk://#diff-199e77af7c2f2b4d04abb350d892e897bfa26ad393246556b9739dae0df9bd5fR29) [[2]](diffhunk://#diff-18b437602b20597aec00cc867eaaa6e4d49f5137812d68811f2d4b54bcbcef63R292-R305)
* Updated the logic in the CallKit mute action handler to reject unmute requests if `allowUnmute` is set to `NO`, providing an error message and reverting the UI toggle. (`src/ios/CordovaCall.m`)
* Ensured that new active call entries default to `allowUnmute: YES`. (`src/ios/CordovaCall.m`)

**JavaScript API:**

* Added a new method `setAllowUnmute` to the JavaScript interface, allowing apps to call this functionality from JS. (`www/CordovaCall.js`)

**Android:**

* Added a stub for `setAllowUnmute` that always returns an error, as this feature is not supported on Android. (`src/android/CordovaCall.java`)