### PR TITLE
always allow programmatic unmute

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-callkit",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "Cordova plugin that lets you use iOS CallKit UI (with PushKit) and Android ConnectionService UI",
   "cordova": {
     "id": "cordova-plugin-callkit",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="cordova-plugin-callkit" version="2.2.3" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="cordova-plugin-callkit" version="2.2.4" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>Cordova CallKit</name>
 
     <js-module name="VoIPPushNotification" src="www/VoIPPushNotification.js">

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -558,10 +558,14 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         // Pre-populate callbackMap before requestTransaction: performSetMutedCallAction fires
         // before the requestTransaction completion block, so the entry must already be present.
         self.activeCalls[sessionId][@"callbackMap"][unmuteAction.UUID.UUIDString] = [@{ @"callbackId": command.callbackId, @"event": @"unmute" } mutableCopy];
+        // Flag that a programmatic unmute is in flight so that any secondary performSetMutedCallAction
+        // invocations (CallKit occasionally fires the delegate twice) also bypass the allowUnmute guard.
+        self.activeCalls[sessionId][@"pendingProgrammaticUnmute"] = @YES;
         [self.callController requestTransaction:transaction completion:^(NSError * _Nullable error) {
             if (error != nil) {
                 // Transaction was rejected before reaching performSetMutedCallAction — clean up.
                 [self.activeCalls[sessionId][@"callbackMap"] removeObjectForKey:unmuteAction.UUID.UUIDString];
+                self.activeCalls[sessionId][@"pendingProgrammaticUnmute"] = @NO;
                 [self logMessage:@"Error occurred unmuting Call"];
                 NSDictionary *resultDict = @{ @"message": @"An error occurred", @"sessionId": sessionId };
                 CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:resultDict];
@@ -1141,6 +1145,16 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         return;
     }
 
+    // If a programmatic unmute is in flight and CallKit fires a secondary unmute action (different UUID),
+    // fulfill it unconditionally — allowUnmute only gates UI-initiated requests.
+    BOOL pendingProgrammaticUnmute = [self.activeCalls[sessionId][@"pendingProgrammaticUnmute"] boolValue];
+    if (!isMuted && pendingProgrammaticUnmute) {
+        self.activeCalls[sessionId][@"pendingProgrammaticUnmute"] = @NO;
+        [action fulfill];
+        [self logMessage:@"performSetMutedCallAction: secondary programmatic unmute action fulfilled"];
+        return;
+    }
+
     BOOL allowUnmute = [self.activeCalls[sessionId][@"allowUnmute"] boolValue];
     if (!isMuted && !allowUnmute) {
         // If this is an unmute request and allowUnmute is NO for this session, fail the action.
@@ -1257,7 +1271,8 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         @"pendingActivateAudioSessionEmits": [NSMutableArray array],
         @"pendingDeactivateAudioSessionEmits": [NSMutableArray array],
         @"pendingDismiss": @NO,
-        @"allowUnmute": @YES
+        @"allowUnmute": @YES,
+        @"pendingProgrammaticUnmute": @NO
     } mutableCopy];
 }
 


### PR DESCRIPTION
related to https://github.com/iotum/facetalk/issues/12798#issuecomment-4652255403

in short: a host can unmute anyone even when the meeting is in presentation.


context: native side execution, when a host remotely unmute a guest (before this PR)

<img width="783" height="229" alt="Screenshot 2026-06-08 174458" src="https://github.com/user-attachments/assets/41c06c67-a5e3-41fb-b8dc-5d9d842fc92d" />
