### PR TITLE
delay sendCall/answerCall/unhold until after WebRTC ADM init, allow manual setupAudioSession

### DIFF
--- a/src/ios/CordovaCall.h
+++ b/src/ios/CordovaCall.h
@@ -22,6 +22,7 @@
 - (void)updateProviderConfig;
 - (void)setupAudioSession;
 - (void)teardownAudioSession;
+- (void)setupAudioSession:(CDVInvokedUrlCommand*)command;
 
 - (void)setAppName:(CDVInvokedUrlCommand*)command;
 - (void)setIcon:(CDVInvokedUrlCommand*)command;

--- a/src/ios/CordovaCall.h
+++ b/src/ios/CordovaCall.h
@@ -1,8 +1,9 @@
 #import <Cordova/CDV.h>
 #import <PushKit/PushKit.h>
 #import <CallKit/CallKit.h>
+#import <WebRTC/RTCAudioSession.h>
 
-@interface CordovaCall : CDVPlugin <PKPushRegistryDelegate, CXProviderDelegate>
+@interface CordovaCall : CDVPlugin <PKPushRegistryDelegate, CXProviderDelegate, RTCAudioSessionDelegate>
 
 // PushKit
 @property (nonatomic, copy) NSString *VoIPPushCallbackId;

--- a/src/ios/CordovaCall.h
+++ b/src/ios/CordovaCall.h
@@ -1,7 +1,8 @@
 #import <Cordova/CDV.h>
 #import <PushKit/PushKit.h>
 #import <CallKit/CallKit.h>
-#import <WebRTC/RTCAudioSession.h>
+
+@protocol RTCAudioSessionDelegate;
 
 @interface CordovaCall : CDVPlugin <PKPushRegistryDelegate, CXProviderDelegate, RTCAudioSessionDelegate>
 

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -61,6 +61,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     self.callController = [[CXCallController alloc] init];
     self.activeCalls = [[NSMutableDictionary alloc] init];
     callbackCleanupQueue = dispatch_queue_create("cordova.callkit.callbackCleanupQueue", DISPATCH_QUEUE_SERIAL);
+    [[RTCAudioSession sharedInstance] addDelegate:self];
     //initialize callback dictionary
     callbackIds = [[NSMutableDictionary alloc]initWithCapacity:5];
     [callbackIds setObject:[NSMutableArray array] forKey:@"answer"];
@@ -932,51 +933,64 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     [[RTCAudioSession sharedInstance] audioSessionDidActivate:audioSession];
     [RTCAudioSession sharedInstance].isAudioEnabled = YES;
     monitorAudioRouteChange = YES;
+    // Pending activate emits (answer, unhold, sendCall) are deferred to
+    // audioSessionDidStartPlayOrRecord: so JS is not notified until the WebRTC
+    // ADM has started initializing
+}
 
-    // Process deferred callbacks for didActivateAudioSession (answer, unhold, sendCall).
-    // UUID in callbackMap = programmatic → resolve promise; else = UI-initiated → emit event.
-    for (NSString *sessionId in self.activeCalls) {
-        NSMutableArray *pendingEmits = self.activeCalls[sessionId][@"pendingActivateAudioSessionEmits"];
-        if (!pendingEmits || pendingEmits.count == 0) continue;
-        NSArray *pendingItems = [pendingEmits copy];
-        [pendingEmits removeAllObjects];
-        for (NSDictionary *item in pendingItems) {
-            NSString *uuidStr = item[@"uuid"];
-            NSString *eventType = item[@"type"];
-            if (self.activeCalls[sessionId][@"callbackMap"][uuidStr]) {
-                // Programmatic action: resolve the JS promise only.
-                [self resolveCommandForSessionId:sessionId actionUUIDString:uuidStr];
-            } else if ([eventType isEqualToString:@"answer"]) {
-                [self logMessage:[NSString stringWithFormat:@"didActivateAudioSession: emitting deferred answer for sessionId=%@", sessionId]];
-                if ([callbackIds[@"answer"] count] == 0) {
-                    [pendingCallResponses addObject:@{ @"type": PENDING_RESPONSE_ANSWER, @"sessionId": sessionId }];
+// RTCAudioSessionDelegate — fires on the WebRTC audio thread once the audio unit
+// has started and the ADM is fully initialized.
+- (void)audioSessionDidStartPlayOrRecord:(RTCAudioSession *)session
+{
+    // Callbacks must reach JS on the main thread.
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self logMessage:@"audioSessionDidStartPlayOrRecord: WebRTC ADM ready, emitting deferred activate callbacks"];
+
+        // Process deferred callbacks for didActivateAudioSession (answer, unhold, sendCall).
+        // UUID in callbackMap = programmatic → resolve promise; else = UI-initiated → emit event.
+        for (NSString *sessionId in self.activeCalls) {
+            NSMutableArray *pendingEmits = self.activeCalls[sessionId][@"pendingActivateAudioSessionEmits"];
+            if (!pendingEmits || pendingEmits.count == 0) continue;
+            NSArray *pendingItems = [pendingEmits copy];
+            [pendingEmits removeAllObjects];
+            for (NSDictionary *item in pendingItems) {
+                NSString *uuidStr = item[@"uuid"];
+                NSString *eventType = item[@"type"];
+                if (self.activeCalls[sessionId][@"callbackMap"][uuidStr]) {
+                    // Programmatic action: resolve the JS promise only.
+                    [self resolveCommandForSessionId:sessionId actionUUIDString:uuidStr];
+                } else if ([eventType isEqualToString:@"answer"]) {
+                    [self logMessage:[NSString stringWithFormat:@"audioSessionDidStartPlayOrRecord: emitting deferred answer for sessionId=%@", sessionId]];
+                    if ([callbackIds[@"answer"] count] == 0) {
+                        [pendingCallResponses addObject:@{ @"type": PENDING_RESPONSE_ANSWER, @"sessionId": sessionId }];
+                    } else {
+                        [self triggerCordovaEventForCallResponse:@"answer" sessionId:sessionId];
+                    }
+                } else if ([eventType isEqualToString:@"sendCall"]) {
+                    // UI-initiated (recents): emit to sendCall event listeners.
+                    NSDictionary *callData = pendingStartCallData;
+                    pendingStartCallData = nil;
+                    if ([callbackIds[@"sendCall"] count] == 0) {
+                        pendingCallFromRecents = callData;
+                    } else {
+                        for (id callbackId in callbackIds[@"sendCall"]) {
+                            CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:callData];
+                            [pluginResult setKeepCallbackAsBool:YES];
+                            [self.commandDelegate sendPluginResult:pluginResult callbackId:callbackId];
+                        }
+                    }
                 } else {
-                    [self triggerCordovaEventForCallResponse:@"answer" sessionId:sessionId];
-                }
-            } else if ([eventType isEqualToString:@"sendCall"]) {
-                // UI-initiated (recents): emit to sendCall event listeners.
-                NSDictionary *callData = pendingStartCallData;
-                pendingStartCallData = nil;
-                if ([callbackIds[@"sendCall"] count] == 0) {
-                    pendingCallFromRecents = callData;
-                } else {
-                    for (id callbackId in callbackIds[@"sendCall"]) {
-                        CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:callData];
+                    // UI-initiated action: emit to event listeners only.
+                    NSDictionary *resultDict = @{ @"message": [NSString stringWithFormat:@"%@ event called successfully", eventType], @"sessionId": sessionId };
+                    for (id callbackId in callbackIds[eventType]) {
+                        CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:resultDict];
                         [pluginResult setKeepCallbackAsBool:YES];
                         [self.commandDelegate sendPluginResult:pluginResult callbackId:callbackId];
                     }
                 }
-            } else {
-                // UI-initiated action: emit to event listeners only.
-                NSDictionary *resultDict = @{ @"message": [NSString stringWithFormat:@"%@ event called successfully", eventType], @"sessionId": sessionId };
-                for (id callbackId in callbackIds[eventType]) {
-                    CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:resultDict];
-                    [pluginResult setKeepCallbackAsBool:YES];
-                    [self.commandDelegate sendPluginResult:pluginResult callbackId:callbackId];
-                }
             }
         }
-    }
+    });
 }
 
 - (void)provider:(CXProvider *)provider didDeactivateAudioSession:(AVAudioSession *)audioSession

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -1479,11 +1479,11 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 - (void)dealloc;
 {
     [self _closeAllSockets];
+    [[RTCAudioSession sharedInstance] removeDelegate:self];
 }
 
 - (void)onReset;
 {
-    [[RTCAudioSession sharedInstance] removeDelegate:self];
     [super onReset];
 }
 

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -32,7 +32,6 @@ UIBackgroundTaskIdentifier bgTask;
 NSMutableArray* pendingCallResponses;
 NSString* const PENDING_RESPONSE_ANSWER = @"pendingResponseAnswer";
 NSString* const PENDING_RESPONSE_REJECT = @"pendingResponseReject";
-dispatch_queue_t callbackCleanupQueue;
 
 // Saved audio session state captured before setupAudioSession; restored in teardownAudioSession.
 AVAudioSessionCategory _savedAudioCategory;
@@ -60,7 +59,6 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     [self.provider setDelegate:self queue:nil];
     self.callController = [[CXCallController alloc] init];
     self.activeCalls = [[NSMutableDictionary alloc] init];
-    callbackCleanupQueue = dispatch_queue_create("cordova.callkit.callbackCleanupQueue", DISPATCH_QUEUE_SERIAL);
     [[RTCAudioSession sharedInstance] addDelegate:self];
     //initialize callback dictionary
     callbackIds = [[NSMutableDictionary alloc]initWithCapacity:5];
@@ -589,8 +587,8 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     NSString *sessionIdCopy = [sessionId copy];
     NSString *uuidStrCopy = [uuidStr copy];
     // Delay callbackMap cleanup so duplicate CallKit callbacks with the same UUID from Callkit reconciliation
-    // are still treated as programmatic. Removal is serialized on callbackCleanupQueue.
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(30 * NSEC_PER_SEC)), callbackCleanupQueue, ^{
+    // are still treated as programmatic. Keep this on main to match activeCalls/callbackMap access confinement.
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(30 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         NSMutableDictionary *call = self.activeCalls[sessionIdCopy];
         if (!call) return;
         NSMutableDictionary *callbackMap = call[@"callbackMap"];
@@ -948,7 +946,8 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 
         // Process deferred callbacks for didActivateAudioSession (answer, unhold, sendCall).
         // UUID in callbackMap = programmatic → resolve promise; else = UI-initiated → emit event.
-        for (NSString *sessionId in self.activeCalls) {
+        NSArray *sessionIds = [self.activeCalls allKeys];
+        for (NSString *sessionId in sessionIds) {
             NSMutableArray *pendingEmits = self.activeCalls[sessionId][@"pendingActivateAudioSessionEmits"];
             if (!pendingEmits || pendingEmits.count == 0) continue;
             NSArray *pendingItems = [pendingEmits copy];

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -38,7 +38,6 @@ AVAudioSessionCategory _savedAudioCategory;
 AVAudioSessionMode _savedAudioMode;
 AVAudioSessionCategoryOptions _savedAudioCategoryOptions = 0;
 BOOL _audioSessionStateSaved = NO;
-BOOL _audioSessionConfiguredForCall = NO;
 
 NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 
@@ -136,22 +135,6 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 {
     @try {
         AVAudioSession *sessionInstance = [AVAudioSession sharedInstance];
-        AVAudioSessionCategoryOptions targetOptions = AVAudioSessionCategoryOptionAllowBluetooth
-                                                   | AVAudioSessionCategoryOptionAllowAirPlay
-                                                   | AVAudioSessionCategoryOptionAllowBluetoothA2DP;
-
-        // AVAudioSessionModeVoiceChat enables iOS hardware AEC (via the Voice Processing I/O audio unit).
-        // WebRTC software AEC/AGC/NS is disabled via audioSourceWithConstraints in PluginGetUserMedia
-        // to prevent double-processing on top of the iOS hardware AEC.
-        AVAudioSessionMode targetMode = hasVideo ? AVAudioSessionModeVideoChat : AVAudioSessionModeVoiceChat;
-
-        BOOL alreadyConfigured = [sessionInstance.category isEqualToString:AVAudioSessionCategoryPlayAndRecord]
-                              && sessionInstance.categoryOptions == targetOptions
-                              && [sessionInstance.mode isEqualToString:targetMode];
-        if (_audioSessionConfiguredForCall && alreadyConfigured) {
-            [self logMessage:[NSString stringWithFormat:@"setupAudioSession: already configured, skipping duplicate setup (mode=%@)", targetMode]];
-            return;
-        }
 
         // Capture the host app's audio session state the first time we configure it for a call,
         // so teardownAudioSession can restore exactly what was there before.
@@ -166,13 +149,19 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 
         NSError *categoryError = nil;
         BOOL categoryConfigured = [sessionInstance setCategory:AVAudioSessionCategoryPlayAndRecord
-                                                   withOptions:targetOptions
+                                                   withOptions: AVAudioSessionCategoryOptionAllowBluetooth
+                                                              | AVAudioSessionCategoryOptionAllowAirPlay
+                                                              | AVAudioSessionCategoryOptionAllowBluetoothA2DP
                                                          error:&categoryError];
         if (!categoryConfigured) {
             [self logMessage:[NSString stringWithFormat:@"Failed to set audio session category: %@", categoryError]];
         }
 
         NSError *modeError = nil;
+        // AVAudioSessionModeVoiceChat enables iOS hardware AEC (via the Voice Processing I/O audio unit).
+        // WebRTC software AEC/AGC/NS is disabled via audioSourceWithConstraints in PluginGetUserMedia
+        // to prevent double-processing on top of the iOS hardware AEC.
+        AVAudioSessionMode targetMode = hasVideo ? AVAudioSessionModeVideoChat : AVAudioSessionModeVoiceChat;
         BOOL modeConfigured = [sessionInstance setMode:targetMode error:&modeError];
         if (!modeConfigured) {
             [self logMessage:[NSString stringWithFormat:@"Failed to set audio session mode: %@", modeError]];
@@ -186,10 +175,11 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         // libwebrtc internally — so we override it here to keep the mode consistent.
         RTCAudioSessionConfiguration *webRTCConfig = [RTCAudioSessionConfiguration webRTCConfiguration];
         webRTCConfig.category = AVAudioSessionCategoryPlayAndRecord;
-        webRTCConfig.categoryOptions = targetOptions;
+        webRTCConfig.categoryOptions = AVAudioSessionCategoryOptionAllowBluetooth
+                                     | AVAudioSessionCategoryOptionAllowAirPlay
+                                     | AVAudioSessionCategoryOptionAllowBluetoothA2DP;
         webRTCConfig.mode = targetMode;  // AVAudioSessionMode is NSString* in ObjC, no .rawValue needed
         [RTCAudioSessionConfiguration setWebRTCConfiguration:webRTCConfig];
-        _audioSessionConfiguredForCall = YES;
         [self logMessage:[NSString stringWithFormat:@"setupAudioSession: RTCAudioSessionConfiguration updated to mode=%@", targetMode]];
     }
     @catch (NSException *exception) {
@@ -223,7 +213,6 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         [self logMessage:[NSString stringWithFormat:@"teardownAudioSession: audio session restored to %@/%@ (options: %lu)", categoryToRestore, modeToRestore, (unsigned long)optionsToRestore]];
 
         // Clear the saved state so the next call captures a fresh snapshot.
-        _audioSessionConfiguredForCall = NO;
         _audioSessionStateSaved = NO;
         _savedAudioCategory = nil;
         _savedAudioMode = nil;
@@ -1494,6 +1483,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 
 - (void)onReset;
 {
+    [[RTCAudioSession sharedInstance] removeDelegate:self];
     [super onReset];
 }
 

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -544,7 +544,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     if (call) {
         CXSetMutedCallAction *muteAction = [[CXSetMutedCallAction alloc] initWithCallUUID:call.UUID muted:YES];
         CXTransaction *transaction = [[CXTransaction alloc] initWithAction:muteAction];
-        [self logMessage:[NSString stringWithFormat:@"Programmatically Muting Call: %@", sessionId]];
+        [self logMessage:[NSString stringWithFormat:@"Programmatically Muting Call: sessionId=%@, actionUUID=%@", sessionId, muteAction.UUID.UUIDString]];
         // Pre-populate callbackMap before requestTransaction: performSetMutedCallAction fires
         // before the requestTransaction completion block, so the entry must already be present.
         self.activeCalls[sessionId][@"callbackMap"][muteAction.UUID.UUIDString] = [@{ @"callbackId": command.callbackId, @"event": @"mute" } mutableCopy];
@@ -552,7 +552,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
             if (error != nil) {
                 // Transaction was rejected before reaching performSetMutedCallAction — clean up.
                 [self.activeCalls[sessionId][@"callbackMap"] removeObjectForKey:muteAction.UUID.UUIDString];
-                [self logMessage:@"Error occurred muting Call"];
+                [self logMessage:[NSString stringWithFormat:@"Error occurred muting Call: sessionId=%@, actionUUID=%@, error=%@", sessionId, muteAction.UUID.UUIDString, error.localizedDescription]];
                 NSDictionary *resultDict = @{ @"message": @"An error occurred", @"sessionId": sessionId };
                 CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:resultDict];
                 [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
@@ -573,7 +573,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     if (call) {
         CXSetMutedCallAction *unmuteAction = [[CXSetMutedCallAction alloc] initWithCallUUID:call.UUID muted:NO];
         CXTransaction *transaction = [[CXTransaction alloc] initWithAction:unmuteAction];
-        [self logMessage:[NSString stringWithFormat:@"Programmatically Unmuting Call: %@", sessionId]];
+        [self logMessage:[NSString stringWithFormat:@"Programmatically Unmuting Call: sessionId=%@, actionUUID=%@", sessionId, unmuteAction.UUID.UUIDString]];
         // Pre-populate callbackMap before requestTransaction: performSetMutedCallAction fires
         // before the requestTransaction completion block, so the entry must already be present.
         self.activeCalls[sessionId][@"callbackMap"][unmuteAction.UUID.UUIDString] = [@{ @"callbackId": command.callbackId, @"event": @"unmute" } mutableCopy];
@@ -581,7 +581,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
             if (error != nil) {
                 // Transaction was rejected before reaching performSetMutedCallAction — clean up.
                 [self.activeCalls[sessionId][@"callbackMap"] removeObjectForKey:unmuteAction.UUID.UUIDString];
-                [self logMessage:@"Error occurred unmuting Call"];
+                [self logMessage:[NSString stringWithFormat:@"Error occurred unmuting Call: sessionId=%@, actionUUID=%@, error=%@", sessionId, unmuteAction.UUID.UUIDString, error.localizedDescription]];
                 NSDictionary *resultDict = @{ @"message": @"An error occurred", @"sessionId": sessionId };
                 CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:resultDict];
                 [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
@@ -600,18 +600,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 {
     NSMutableDictionary *entry = self.activeCalls[sessionId][@"callbackMap"][uuidStr];
     if (!entry) return;
-    // TODO: Remove the queued callbackMap cleanup once the Callkit reconciliation duplicate callback issue is fixed
-    // [self.activeCalls[sessionId][@"callbackMap"] removeObjectForKey:uuidStr];
-    NSString *sessionIdCopy = [sessionId copy];
-    NSString *uuidStrCopy = [uuidStr copy];
-    // Delay callbackMap cleanup so duplicate CallKit callbacks with the same UUID from Callkit reconciliation
-    // are still treated as programmatic. Keep this on main to match activeCalls/callbackMap access confinement.
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(30 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        NSMutableDictionary *call = self.activeCalls[sessionIdCopy];
-        if (!call) return;
-        NSMutableDictionary *callbackMap = call[@"callbackMap"];
-        [callbackMap removeObjectForKey:uuidStrCopy];
-    });
+    [self.activeCalls[sessionId][@"callbackMap"] removeObjectForKey:uuidStr];
     NSString *callbackId = entry[@"callbackId"];
     if (!callbackId) return;
     [self logMessage:[NSString stringWithFormat:@"resolved %@ promise for sessionId: %@", entry[@"event"], sessionId]];
@@ -1171,11 +1160,11 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     BOOL isMuted = action.muted;
     NSString *sessionId = [self sessionIdForUUID:action.callUUID];
     if (!sessionId) {
-        [self logMessage:[NSString stringWithFormat:@"performSetMutedCallAction: no sessionId found for callUUID %@, ignoring %@ event", action.callUUID.UUIDString, isMuted ? @"mute" : @"unmute"]];
+        [self logMessage:[NSString stringWithFormat:@"performSetMutedCallAction: no sessionId found for callUUID=%@, actionUUID=%@, ignoring %@ event", action.callUUID.UUIDString, action.UUID.UUIDString, isMuted ? @"mute" : @"unmute"]];
         [action fulfill];
         return;
     }
-    [self logMessage:[NSString stringWithFormat:@"CallKit performSetMutedCallAction received %@ event, sessionId: %@", isMuted ? @"mute" : @"unmute", sessionId]];
+    [self logMessage:[NSString stringWithFormat:@"CallKit performSetMutedCallAction received %@ event, sessionId=%@, actionUUID=%@", isMuted ? @"mute" : @"unmute", sessionId, action.UUID.UUIDString]];
 
     if (self.activeCalls[sessionId][@"callbackMap"][action.UUID.UUIDString]) {
         [action fulfill];

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -38,6 +38,7 @@ AVAudioSessionCategory _savedAudioCategory;
 AVAudioSessionMode _savedAudioMode;
 AVAudioSessionCategoryOptions _savedAudioCategoryOptions = 0;
 BOOL _audioSessionStateSaved = NO;
+BOOL _audioSessionConfiguredForCall = NO;
 
 NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 
@@ -135,6 +136,22 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 {
     @try {
         AVAudioSession *sessionInstance = [AVAudioSession sharedInstance];
+        AVAudioSessionCategoryOptions targetOptions = AVAudioSessionCategoryOptionAllowBluetooth
+                                                   | AVAudioSessionCategoryOptionAllowAirPlay
+                                                   | AVAudioSessionCategoryOptionAllowBluetoothA2DP;
+
+        // AVAudioSessionModeVoiceChat enables iOS hardware AEC (via the Voice Processing I/O audio unit).
+        // WebRTC software AEC/AGC/NS is disabled via audioSourceWithConstraints in PluginGetUserMedia
+        // to prevent double-processing on top of the iOS hardware AEC.
+        AVAudioSessionMode targetMode = hasVideo ? AVAudioSessionModeVideoChat : AVAudioSessionModeVoiceChat;
+
+        BOOL alreadyConfigured = [sessionInstance.category isEqualToString:AVAudioSessionCategoryPlayAndRecord]
+                              && sessionInstance.categoryOptions == targetOptions
+                              && [sessionInstance.mode isEqualToString:targetMode];
+        if (_audioSessionConfiguredForCall && alreadyConfigured) {
+            [self logMessage:[NSString stringWithFormat:@"setupAudioSession: already configured, skipping duplicate setup (mode=%@)", targetMode]];
+            return;
+        }
 
         // Capture the host app's audio session state the first time we configure it for a call,
         // so teardownAudioSession can restore exactly what was there before.
@@ -149,19 +166,13 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 
         NSError *categoryError = nil;
         BOOL categoryConfigured = [sessionInstance setCategory:AVAudioSessionCategoryPlayAndRecord
-                                                   withOptions: AVAudioSessionCategoryOptionAllowBluetooth
-                                                              | AVAudioSessionCategoryOptionAllowAirPlay
-                                                              | AVAudioSessionCategoryOptionAllowBluetoothA2DP
+                                                   withOptions:targetOptions
                                                          error:&categoryError];
         if (!categoryConfigured) {
             [self logMessage:[NSString stringWithFormat:@"Failed to set audio session category: %@", categoryError]];
         }
 
         NSError *modeError = nil;
-        // AVAudioSessionModeVoiceChat enables iOS hardware AEC (via the Voice Processing I/O audio unit).
-        // WebRTC software AEC/AGC/NS is disabled via audioSourceWithConstraints in PluginGetUserMedia
-        // to prevent double-processing on top of the iOS hardware AEC.
-        AVAudioSessionMode targetMode = hasVideo ? AVAudioSessionModeVideoChat : AVAudioSessionModeVoiceChat;
         BOOL modeConfigured = [sessionInstance setMode:targetMode error:&modeError];
         if (!modeConfigured) {
             [self logMessage:[NSString stringWithFormat:@"Failed to set audio session mode: %@", modeError]];
@@ -175,11 +186,10 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         // libwebrtc internally — so we override it here to keep the mode consistent.
         RTCAudioSessionConfiguration *webRTCConfig = [RTCAudioSessionConfiguration webRTCConfiguration];
         webRTCConfig.category = AVAudioSessionCategoryPlayAndRecord;
-        webRTCConfig.categoryOptions = AVAudioSessionCategoryOptionAllowBluetooth
-                                     | AVAudioSessionCategoryOptionAllowAirPlay
-                                     | AVAudioSessionCategoryOptionAllowBluetoothA2DP;
+        webRTCConfig.categoryOptions = targetOptions;
         webRTCConfig.mode = targetMode;  // AVAudioSessionMode is NSString* in ObjC, no .rawValue needed
         [RTCAudioSessionConfiguration setWebRTCConfiguration:webRTCConfig];
+        _audioSessionConfiguredForCall = YES;
         [self logMessage:[NSString stringWithFormat:@"setupAudioSession: RTCAudioSessionConfiguration updated to mode=%@", targetMode]];
     }
     @catch (NSException *exception) {
@@ -213,6 +223,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         [self logMessage:[NSString stringWithFormat:@"teardownAudioSession: audio session restored to %@/%@ (options: %lu)", categoryToRestore, modeToRestore, (unsigned long)optionsToRestore]];
 
         // Clear the saved state so the next call captures a fresh snapshot.
+        _audioSessionConfiguredForCall = NO;
         _audioSessionStateSaved = NO;
         _savedAudioCategory = nil;
         _savedAudioMode = nil;
@@ -221,6 +232,13 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     @catch (NSException *exception) {
         [self logMessage:@"Unknown error returned from teardownAudioSession"];
     }
+}
+
+- (void)setupAudioSession:(CDVInvokedUrlCommand*)command
+{
+    [self setupAudioSession];
+    CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Audio session setup complete"];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
 - (void)setAppName:(CDVInvokedUrlCommand*)command

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -933,7 +933,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     monitorAudioRouteChange = YES;
     // Pending activate emits (answer, unhold, sendCall) are deferred to
     // audioSessionDidStartPlayOrRecord: so JS is not notified until the WebRTC
-    // ADM has started initializing
+    // audio unit has started and the ADM is fully initialized.
 }
 
 // RTCAudioSessionDelegate — fires on the WebRTC audio thread once the audio unit

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -32,6 +32,7 @@ UIBackgroundTaskIdentifier bgTask;
 NSMutableArray* pendingCallResponses;
 NSString* const PENDING_RESPONSE_ANSWER = @"pendingResponseAnswer";
 NSString* const PENDING_RESPONSE_REJECT = @"pendingResponseReject";
+dispatch_queue_t callbackCleanupQueue;
 
 // Saved audio session state captured before setupAudioSession; restored in teardownAudioSession.
 AVAudioSessionCategory _savedAudioCategory;
@@ -59,6 +60,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     [self.provider setDelegate:self queue:nil];
     self.callController = [[CXCallController alloc] init];
     self.activeCalls = [[NSMutableDictionary alloc] init];
+    callbackCleanupQueue = dispatch_queue_create("cordova.callkit.callbackCleanupQueue", DISPATCH_QUEUE_SERIAL);
     //initialize callback dictionary
     callbackIds = [[NSMutableDictionary alloc]initWithCapacity:5];
     [callbackIds setObject:[NSMutableArray array] forKey:@"answer"];
@@ -581,7 +583,18 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
 {
     NSMutableDictionary *entry = self.activeCalls[sessionId][@"callbackMap"][uuidStr];
     if (!entry) return;
-    [self.activeCalls[sessionId][@"callbackMap"] removeObjectForKey:uuidStr];
+    // TODO: Remove the queued callbackMap cleanup once the Callkit reconciliation duplicate callback issue is fixed
+    // [self.activeCalls[sessionId][@"callbackMap"] removeObjectForKey:uuidStr];
+    NSString *sessionIdCopy = [sessionId copy];
+    NSString *uuidStrCopy = [uuidStr copy];
+    // Delay callbackMap cleanup so duplicate CallKit callbacks with the same UUID from Callkit reconciliation
+    // are still treated as programmatic. Removal is serialized on callbackCleanupQueue.
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(30 * NSEC_PER_SEC)), callbackCleanupQueue, ^{
+        NSMutableDictionary *call = self.activeCalls[sessionIdCopy];
+        if (!call) return;
+        NSMutableDictionary *callbackMap = call[@"callbackMap"];
+        [callbackMap removeObjectForKey:uuidStrCopy];
+    });
     NSString *callbackId = entry[@"callbackId"];
     if (!callbackId) return;
     [self logMessage:[NSString stringWithFormat:@"resolved %@ promise for sessionId: %@", entry[@"event"], sessionId]];
@@ -1141,6 +1154,7 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
         return;
     }
 
+    // UI-initiated mute/unmute: emit to event listeners only.
     BOOL allowUnmute = [self.activeCalls[sessionId][@"allowUnmute"] boolValue];
     if (!isMuted && !allowUnmute) {
         // If this is an unmute request and allowUnmute is NO for this session, fail the action.
@@ -1151,7 +1165,6 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
     } else {
         [action fulfill];
 
-        // UI-initiated mute/unmute: emit to event listeners only.
         for (id callbackId in callbackIds[isMuted ? @"mute" : @"unmute"]) {
             [self logMessage:[NSString stringWithFormat:@"Sending %@ event to JS", isMuted ? @"mute" : @"unmute"]];
             NSDictionary *resultDict = @{ @"message": [NSString stringWithFormat:@"%@ event called successfully", isMuted ? @"mute" : @"unmute"], @"sessionId": sessionId };

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -964,8 +964,11 @@ NSString* const KEY_VOIP_PUSH_TOKEN = @"PK_deviceToken";
                 } else if ([eventType isEqualToString:@"sendCall"]) {
                     // UI-initiated (recents): emit to sendCall event listeners.
                     NSDictionary *callData = pendingStartCallData;
+                    if (callData == nil) {
+                        [self logMessage:[NSString stringWithFormat:@"audioSessionDidStartPlayOrRecord: pendingStartCallData was nil for sessionId=%@; skipping sendCall emit", sessionId]];
+                        continue;
+                    }
                     pendingStartCallData = nil;
-                    if ([callbackIds[@"sendCall"] count] == 0) {
                         pendingCallFromRecents = callData;
                     } else {
                         for (id callbackId in callbackIds[@"sendCall"]) {

--- a/www/CordovaCall.js
+++ b/www/CordovaCall.js
@@ -154,6 +154,10 @@ exports.log = function (message) {
   exec(null, null, "CordovaCall", "log", [message]);
 }
 
+exports.setupAudioSession = function (success, error) {
+  exec(success, error, "CordovaCall", "setupAudioSession", []);
+}
+
 exports.setAllowUnmute = function (sessionId, value, success, error) {
   if (typeof value == "boolean") {
     exec(success, error, "CordovaCall", "setAllowUnmute", [sessionId, value]);


### PR DESCRIPTION
Delay didActivateAudioSession until WebRTC init:

Bug:
- `didActivateAudioSession` was emitting to JS that audio is ready when all it has done was tell WebRTC to spin up via `[RTCAudioSession sharedInstance].isAudioEnabled = YES;`
- This causes us to action on the audio too early, like mute/unmute and can cause potential crashes and race conditions

Fix:
- Listen for the existing WebRTC `audioSessionDidStartPlayOrRecord` so that we know the WebRTC Audio Engine is actually starting
- Still not the ideal callback since this is "starting" and not "started", there does not appear to be a better callback to listen for.

Allow manual setupAudioSession

Bug:
- gUM could be called before WebRTC init audio device

Fix:
- manually call `setupAudioSession` as part of entering the InCallPage